### PR TITLE
ci: add GitHub Actions workflow for static model catalog data image

### DIFF
--- a/.github/workflows/build-and-push-static-model-catalog-data.yml
+++ b/.github/workflows/build-and-push-static-model-catalog-data.yml
@@ -1,0 +1,73 @@
+name: Build and Push Static Model Catalog Data Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'data/**'
+      - 'Dockerfile'
+      - '.github/workflows/build-and-push-static-model-catalog-data.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'data/**'
+      - 'Dockerfile'
+      - '.github/workflows/build-and-push-static-model-catalog-data.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: quay.io
+  IMAGE_NAME: opendatahub/odh-model-metadata-collection
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push static model catalog data image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+      - name: Output static model catalog data image details
+        run: |
+          echo "Static model catalog data image pushed to: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+          echo "Tags:"
+          echo "${{ steps.meta.outputs.tags }}" | sed 's/^/  - /'


### PR DESCRIPTION
## Description
Add automated CI/CD pipeline to build and push static model catalog data images to quay.io/opendatahub/odh-model-metadata-collection.

Key features:
- Triggers on main branch pushes and PRs affecting data/, Dockerfile, or workflow
- Supports manual workflow dispatch for on-demand builds
- Multi-platform builds (linux/amd64, linux/arm64)
- GitHub Actions caching for improved build performance
- Quay.io authentication with secrets management
- Comprehensive tagging strategy (branch, PR, SHA, latest)

This enables automated distribution of model metadata catalogs as container images for consumption by OpenDataHub and RHOAI components.

## How Has This Been Tested?
Followed reference of https://github.com/opendatahub-io/model-registry/blob/main/.github/workflows/build-and-push-async-upload.yml

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
