### PR TITLE
feat: restructure model metadata from boolean properties to labels array

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Go application for extracting, enriching, and cataloging metadata from Red Hat
 - **HuggingFace Collections Integration**: Automatically discovers and processes Red Hat AI validated model collections with version support (v1.0, v2.1, etc.)
 - **OCI Container Analysis**: Extracts model cards from container image layers with annotation-based detection; creates skeleton metadata when extraction fails to ensure enrichment continuity
 - **Metadata Enrichment**: Enriches model metadata with HuggingFace data including date-to-epoch conversion and quality validation, **with modelcard.md data taking priority over external sources**
-- **Automated Tagging**: Automatically adds "validated" and "featured" tags based on model configuration with intelligent tag merging
+- **Automated Tagging**: Automatically adds labels as tags based on model configuration with intelligent tag merging
 - **Registry Integration**: Fetches OCI artifact metadata from container registries
 - **Metadata Reporting**: Comprehensive analysis of metadata completeness, data source tracking, and quality metrics
 - **Flexible CLI**: Configurable input/output paths and processing options with skip flags for individual components
@@ -212,25 +212,22 @@ You can also provide a YAML file with structured model entries supporting both O
 models:
   - type: "oci"
     uri: "registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-base-quantized-w4a16:1.5"
-    validated: true
-    featured: false
+    labels: ["validated"]
   - type: "oci" 
     uri: "registry.redhat.io/rhelai1/modelcar-llama-3-3-70b-instruct:1.5"
-    validated: true
-    featured: true
+    labels: ["validated", "featured"]
   - type: "hf"
     uri: "https://huggingface.co/microsoft/Phi-3.5-mini-instruct"
-    validated: true
-    featured: false
+    labels: ["validated", "lab-teacher"]
 ```
 
 Each model entry supports the following fields:
 - **type**: `"oci"` for registry-based modelcar containers or `"hf"` for HuggingFace model links
 - **uri**: The OCI registry reference or HuggingFace model URL
-- **validated**: Boolean indicating whether the model has been validated (should be `true` for production models)
-  - Models with `validated: true` automatically receive a "validated" tag in their metadata
-- **featured**: Boolean indicating whether the model should be highlighted as featured (defaults to `false`)
-  - Models with `featured: true` automatically receive a "featured" tag in their metadata
+- **labels**: Array of labels that will be added as tags to the model metadata
+  - Common labels include: `"validated"`, `"featured"`, `"lab-teacher"`, `"lab-base"`
+  - Labels are automatically converted to customProperties in the final model catalog
+  - New labels can be added without code changes
 
 ### Version-Specific Index Files
 Generated automatically from HuggingFace collections:
@@ -275,8 +272,9 @@ language:
 license: apache-2.0
 licenseLink: https://www.apache.org/licenses/LICENSE-2.0
 tags:
-  - validated                    # Automatically added when validated: true
-  - featured                     # Automatically added when featured: true
+  - validated                    # From labels array in models-index.yaml
+  - featured                     # From labels array in models-index.yaml
+  - lab-teacher                  # Additional custom labels from models-index.yaml
   - granite                      # Tags from HuggingFace enrichment
   - language                     # Additional tags merged from various sources
 tasks:
@@ -443,7 +441,7 @@ The tool integrates with HuggingFace APIs to:
 4. **Skeleton Creation**: When modelcard extraction fails completely, creates minimal metadata structure for enrichment
 
 **Tag Management**: The tool implements intelligent tag merging:
-- "validated" and "featured" tags are automatically added based on model configuration
+- Labels from the models-index.yaml configuration are automatically added as tags
 - Existing modelcard tags are preserved and merged with HuggingFace enrichment tags
 - Duplicate tags are automatically deduplicated
 - Tag precedence follows the same hierarchy as data prioritization

--- a/data/models-catalog.yaml
+++ b/data/models-catalog.yaml
@@ -1176,6 +1176,9 @@ models:
         facebook:
             metadataType: MetadataStringValue
             string_value: ""
+        lab-teacher:
+            metadataType: MetadataStringValue
+            string_value: ""
         llama:
             metadataType: MetadataStringValue
             string_value: ""
@@ -2120,6 +2123,9 @@ models:
             metadataType: MetadataStringValue
             string_value: ""
         featured:
+            metadataType: MetadataStringValue
+            string_value: ""
+        lab-teacher:
             metadataType: MetadataStringValue
             string_value: ""
         mistral:
@@ -4094,6 +4100,9 @@ models:
             metadataType: MetadataStringValue
             string_value: ""
         granite-3.1:
+            metadataType: MetadataStringValue
+            string_value: ""
+        lab-base:
             metadataType: MetadataStringValue
             string_value: ""
         language:

--- a/data/models-index.yaml
+++ b/data/models-index.yaml
@@ -1,161 +1,167 @@
 models:
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-llama-4-scout-17b-16e-instruct:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-llama-4-scout-17b-16e-instruct-fp8-dynamic:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-llama-4-scout-17b-16e-instruct-quantized-w4a16:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-llama-4-maverick-17b-128e-instruct:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-llama-4-maverick-17b-128e-instruct-fp8:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-mistral-small-3-1-24b-instruct-2503:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-mistral-small-3-1-24b-instruct-2503-quantized-w4a16:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-mistral-small-3-1-24b-instruct-2503-quantized-w8a8:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-mistral-small-3-1-24b-instruct-2503-fp8-dynamic:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-llama-3-3-70b-instruct:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-llama-3-3-70b-instruct-quantized-w4a16:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-llama-3-3-70b-instruct-quantized-w8a8:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-llama-3-3-70b-instruct-fp8-dynamic:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-llama-3-1-8b-instruct:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-llama-3-1-8b-instruct-quantized-w4a16:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-llama-3-1-8b-instruct-quantized-w8a8:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-llama-3-1-8b-instruct-fp8-dynamic:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-instruct:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-instruct-quantized-w4a16:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-instruct-quantized-w8a8:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-instruct-fp8-dynamic:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-phi-4:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-phi-4-quantized-w4a16:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-phi-4-quantized-w8a8:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-phi-4-fp8-dynamic:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-qwen2-5-7b-instruct:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-qwen2-5-7b-instruct-quantized-w4a16:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-qwen2-5-7b-instruct-quantized-w8a8:1.5"
-    validated: true
-    featured: true
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-qwen2-5-7b-instruct-fp8-dynamic:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-mistral-small-24b-instruct-2501:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-mistral-small-24b-instruct-2501-quantized-w4a16:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-mistral-small-24b-instruct-2501-quantized-w8a8:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-mistral-small-24b-instruct-2501-fp8-dynamic:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-mixtral-8x7b-instruct-v0-1:1.4"
-    validated: true
-    featured: true
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-base-quantized-w4a16:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-starter-v2:1.5"
-    validated: true
-    featured: true
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-llama-3-1-nemotron-70b-instruct-hf-fp8-dynamic:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-llama-3-1-nemotron-70b-instruct-hf:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-gemma-2-9b-it-fp8:1.5"
-    validated: true
-    featured: false
-  - type: "oci"
-    uri: "registry.redhat.io/rhelai1/modelcar-gemma-2-9b-it:1.5"
-    validated: true
-    featured: false
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-llama-4-scout-17b-16e-instruct:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-llama-4-scout-17b-16e-instruct-fp8-dynamic:1.5
+  labels:
+  - validated
+  - lab-teacher
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-llama-4-scout-17b-16e-instruct-quantized-w4a16:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-llama-4-maverick-17b-128e-instruct:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-llama-4-maverick-17b-128e-instruct-fp8:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-mistral-small-3-1-24b-instruct-2503:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-mistral-small-3-1-24b-instruct-2503-quantized-w4a16:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-mistral-small-3-1-24b-instruct-2503-quantized-w8a8:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-mistral-small-3-1-24b-instruct-2503-fp8-dynamic:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-llama-3-3-70b-instruct:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-llama-3-3-70b-instruct-quantized-w4a16:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-llama-3-3-70b-instruct-quantized-w8a8:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-llama-3-3-70b-instruct-fp8-dynamic:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-llama-3-1-8b-instruct:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-llama-3-1-8b-instruct-quantized-w4a16:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-llama-3-1-8b-instruct-quantized-w8a8:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-llama-3-1-8b-instruct-fp8-dynamic:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-instruct:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-instruct-quantized-w4a16:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-instruct-quantized-w8a8:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-instruct-fp8-dynamic:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-phi-4:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-phi-4-quantized-w4a16:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-phi-4-quantized-w8a8:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-phi-4-fp8-dynamic:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-qwen2-5-7b-instruct:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-qwen2-5-7b-instruct-quantized-w4a16:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-qwen2-5-7b-instruct-quantized-w8a8:1.5
+  labels:
+  - validated
+  - featured
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-qwen2-5-7b-instruct-fp8-dynamic:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-mistral-small-24b-instruct-2501:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-mistral-small-24b-instruct-2501-quantized-w4a16:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-mistral-small-24b-instruct-2501-quantized-w8a8:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-mistral-small-24b-instruct-2501-fp8-dynamic:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-mixtral-8x7b-instruct-v0-1:1.4
+  labels:
+  - validated
+  - featured
+  - lab-teacher
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-base-quantized-w4a16:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-starter-v2:1.5
+  labels:
+  - validated
+  - featured
+  - lab-base
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-llama-3-1-nemotron-70b-instruct-hf-fp8-dynamic:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-llama-3-1-nemotron-70b-instruct-hf:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-gemma-2-9b-it-fp8:1.5
+  labels:
+  - validated
+- type: oci
+  uri: registry.redhat.io/rhelai1/modelcar-gemma-2-9b-it:1.5
+  labels:
+  - validated

--- a/internal/catalog/catalog.go
+++ b/internal/catalog/catalog.go
@@ -151,7 +151,7 @@ func convertTimestampToString(timestamp *int64) *string {
 // convertTagsToCustomProperties converts all tags to customProperties format
 func convertTagsToCustomProperties(tags []string) map[string]types.MetadataValue {
 	customProps := make(map[string]types.MetadataValue)
-	
+
 	for _, tag := range tags {
 		if tag != "" { // Skip empty tags
 			customProps[tag] = types.MetadataValue{
@@ -160,6 +160,6 @@ func convertTagsToCustomProperties(tags []string) map[string]types.MetadataValue
 			}
 		}
 	}
-	
+
 	return customProps
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,16 +21,13 @@ func TestLoadModelsFromYAML(t *testing.T) {
 			fileContent: `models:
   - type: "oci"
     uri: "registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-base:1.0"
-    validated: true
-    featured: false
+    labels: ["validated"]
   - type: "oci"
     uri: "registry.redhat.io/rhelai1/modelcar-llama-3-2-1b-instruct:1.0"
-    validated: true
-    featured: false
+    labels: ["validated"]
   - type: "hf"
     uri: "https://huggingface.co/microsoft/Phi-3.5-mini-instruct"
-    validated: true
-    featured: true`,
+    labels: ["validated", "featured"]`,
 			expected: []string{
 				"registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-base:1.0",
 				"registry.redhat.io/rhelai1/modelcar-llama-3-2-1b-instruct:1.0",
@@ -49,8 +46,7 @@ func TestLoadModelsFromYAML(t *testing.T) {
 			fileContent: `models:
   - type: "oci"
     uri: "registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-base:1.0"
-    validated: true
-    featured: false`,
+    labels: ["validated"]`,
 			expected: []string{
 				"registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-base:1.0",
 			},

--- a/internal/enrichment/enrichment_test.go
+++ b/internal/enrichment/enrichment_test.go
@@ -344,8 +344,8 @@ func TestUpdateAllModelsWithOCIArtifacts(t *testing.T) {
 	// Create models config with test models
 	modelsConfig := types.ModelsConfig{
 		Models: []types.ModelEntry{
-			{Type: "oci", URI: "registry.example.com/test/model1:latest", Validated: true, Featured: false},
-			{Type: "oci", URI: "registry.example.com/test/model2:latest", Validated: true, Featured: false},
+			{Type: "oci", URI: "registry.example.com/test/model1:latest", Labels: []string{"validated"}},
+			{Type: "oci", URI: "registry.example.com/test/model2:latest", Labels: []string{"validated"}},
 		},
 	}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -4,10 +4,9 @@ import "time"
 
 // ModelEntry represents a single model entry in the models index
 type ModelEntry struct {
-	Type      string `yaml:"type"`      // "oci" for registry-based modelcar or "hf" for HuggingFace models
-	URI       string `yaml:"uri"`       // OCI link or HuggingFace link
-	Validated bool   `yaml:"validated"` // Whether the model has been validated
-	Featured  bool   `yaml:"featured"`  // Whether the model is featured
+	Type   string   `yaml:"type"`   // "oci" for registry-based modelcar or "hf" for HuggingFace models
+	URI    string   `yaml:"uri"`    // OCI link or HuggingFace link
+	Labels []string `yaml:"labels"` // Labels for the model (e.g., "validated", "featured", "lab-teacher", "lab-base")
 }
 
 // ModelsConfig represents the configuration of models to process
@@ -189,18 +188,18 @@ type CatalogOCIArtifact struct {
 
 // CatalogMetadata represents metadata for the catalog output without tags field
 type CatalogMetadata struct {
-	Name                     *string              `yaml:"name"`
-	Provider                 *string              `yaml:"provider"`
-	Description              *string              `yaml:"description"`
-	Readme                   *string              `yaml:"readme"`
-	Language                 []string             `yaml:"language"`
-	License                  *string              `yaml:"license"`
-	LicenseLink              *string              `yaml:"licenseLink"`
-	Tasks                    []string             `yaml:"tasks"`
-	CreateTimeSinceEpoch     *string              `yaml:"createTimeSinceEpoch"`
-	LastUpdateTimeSinceEpoch *string              `yaml:"lastUpdateTimeSinceEpoch"`
+	Name                     *string                  `yaml:"name"`
+	Provider                 *string                  `yaml:"provider"`
+	Description              *string                  `yaml:"description"`
+	Readme                   *string                  `yaml:"readme"`
+	Language                 []string                 `yaml:"language"`
+	License                  *string                  `yaml:"license"`
+	LicenseLink              *string                  `yaml:"licenseLink"`
+	Tasks                    []string                 `yaml:"tasks"`
+	CreateTimeSinceEpoch     *string                  `yaml:"createTimeSinceEpoch"`
+	LastUpdateTimeSinceEpoch *string                  `yaml:"lastUpdateTimeSinceEpoch"`
 	CustomProperties         map[string]MetadataValue `yaml:"customProperties,omitempty"`
-	Artifacts                []CatalogOCIArtifact `yaml:"artifacts"`
+	Artifacts                []CatalogOCIArtifact     `yaml:"artifacts"`
 }
 
 // ModelsCatalog represents the aggregated catalog of all models


### PR DESCRIPTION
Replace individual boolean fields (validated, featured) with generic Labels []string array in ModelEntry struct. This architectural change enables automatic processing of new properties like lab-teacher and lab-base without requiring code modifications.

Key Changes:
- Updated ModelEntry struct to use Labels field instead of booleans
- Converted all 40 models in data/models-index.yaml to labels format
- Modified processing logic to handle generic labels array
- Updated test configurations and documentation
- Maintained backward compatibility for existing functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Label-driven model tagging replaces validated/featured flags; tags now derive automatically from labels.
  - Support for custom labels (e.g., lab-teacher, lab-base); these appear as custom properties in generated catalogs.

- Documentation
  - README updated for labels-based configuration and input examples; removed boolean fields.
  - Added docs on concurrent processing, structured output, and test coverage.

- Refactor
  - Migrated configuration schema from boolean flags to a labels array across samples and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->