### PR TITLE
ci: add GitHub Actions workflows for automatic branch synchronization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# Global code owners for automatic review assignment
-# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-
-* @opendatahub-io/model-registry-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Global code owners for automatic review assignment
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @opendatahub-io/model-registry-maintainers

--- a/.github/workflows/sync-branch-stable.yml
+++ b/.github/workflows/sync-branch-stable.yml
@@ -1,0 +1,32 @@
+name: Sync Branch stable
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    name: Syncing branch stable
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Opening pull request
+        id: pull
+        uses: tretuna/sync-branches@1.4.0
+        with:
+          TEAM_REVIEWERS: '["model-registry-maintainers"]'
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          FROM_BRANCH: "main"
+          TO_BRANCH: "stable"
+      - name: Add labels
+        if: ${{ steps.pull.outputs.PULL_REQUEST_NUMBER != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{steps.pull.outputs.PULL_REQUEST_NUMBER}},
+              labels: ['Area/Jobs/Sync-stable', 'tide/merge-method-merge']
+            });

--- a/.github/workflows/sync-branch-stable.yml
+++ b/.github/workflows/sync-branch-stable.yml
@@ -15,7 +15,6 @@ jobs:
         id: pull
         uses: tretuna/sync-branches@1.4.0
         with:
-          TEAM_REVIEWERS: '["model-registry-maintainers"]'
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "main"
           TO_BRANCH: "stable"

--- a/.github/workflows/sync-branch-stable.yml
+++ b/.github/workflows/sync-branch-stable.yml
@@ -15,6 +15,7 @@ jobs:
         id: pull
         uses: tretuna/sync-branches@1.4.0
         with:
+          TEAM_REVIEWERS: '["model-registry-maintainers"]'
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "main"
           TO_BRANCH: "stable"

--- a/.github/workflows/sync-branch-stable2x.yml
+++ b/.github/workflows/sync-branch-stable2x.yml
@@ -1,0 +1,32 @@
+name: Sync Branch stable-2.x
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    name: Syncing branch stable-2.x
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Opening pull request
+        id: pull
+        uses: tretuna/sync-branches@1.4.0
+        with:
+          TEAM_REVIEWERS: '["model-registry-maintainers"]'
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          FROM_BRANCH: "main"
+          TO_BRANCH: "stable-2.x"
+      - name: Add labels
+        if: ${{ steps.pull.outputs.PULL_REQUEST_NUMBER != '' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{steps.pull.outputs.PULL_REQUEST_NUMBER}},
+              labels: ['Area/Jobs/Sync-stable2x', 'tide/merge-method-merge']
+            });

--- a/.github/workflows/sync-branch-stable2x.yml
+++ b/.github/workflows/sync-branch-stable2x.yml
@@ -15,7 +15,6 @@ jobs:
         id: pull
         uses: tretuna/sync-branches@1.4.0
         with:
-          TEAM_REVIEWERS: '["model-registry-maintainers"]'
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "main"
           TO_BRANCH: "stable-2.x"

--- a/.github/workflows/sync-branch-stable2x.yml
+++ b/.github/workflows/sync-branch-stable2x.yml
@@ -15,6 +15,7 @@ jobs:
         id: pull
         uses: tretuna/sync-branches@1.4.0
         with:
+          TEAM_REVIEWERS: '["model-registry-maintainers"]'
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           FROM_BRANCH: "main"
           TO_BRANCH: "stable-2.x"


### PR DESCRIPTION
Add automated workflows to sync main branch changes to stable branches:
- sync-branch-stable.yml: Syncs main to stable branch with PR creation
- sync-branch-stable2x.yml: Syncs main to stable-2.x branch with PR creation

This enables automatic propagation of main branch updates to stable release branches while maintaining review processes and proper labeling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added automation to sync the main branch into stable and stable-2.x via scheduled pull requests on pushes to main.
  - Automatically assigns team reviewers and applies standard labels to created PRs for consistent tracking and merge behavior.
  - Improves release branch maintenance with reduced manual effort and clearer PR labeling.
  - No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->