### PR TITLE
chore(data): remove deprecated lab-teacher and lab-base labels from model index

### DIFF
--- a/data/models-catalog.yaml
+++ b/data/models-catalog.yaml
@@ -1176,9 +1176,6 @@ models:
         facebook:
             metadataType: MetadataStringValue
             string_value: ""
-        lab-teacher:
-            metadataType: MetadataStringValue
-            string_value: ""
         llama:
             metadataType: MetadataStringValue
             string_value: ""
@@ -2123,9 +2120,6 @@ models:
             metadataType: MetadataStringValue
             string_value: ""
         featured:
-            metadataType: MetadataStringValue
-            string_value: ""
-        lab-teacher:
             metadataType: MetadataStringValue
             string_value: ""
         mistral:
@@ -4100,9 +4094,6 @@ models:
             metadataType: MetadataStringValue
             string_value: ""
         granite-3.1:
-            metadataType: MetadataStringValue
-            string_value: ""
-        lab-base:
             metadataType: MetadataStringValue
             string_value: ""
         language:

--- a/data/models-index.yaml
+++ b/data/models-index.yaml
@@ -7,7 +7,6 @@ models:
   uri: registry.redhat.io/rhelai1/modelcar-llama-4-scout-17b-16e-instruct-fp8-dynamic:1.5
   labels:
   - validated
-  - lab-teacher
 - type: oci
   uri: registry.redhat.io/rhelai1/modelcar-llama-4-scout-17b-16e-instruct-quantized-w4a16:1.5
   labels:
@@ -138,7 +137,6 @@ models:
   labels:
   - validated
   - featured
-  - lab-teacher
 - type: oci
   uri: registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-base-quantized-w4a16:1.5
   labels:
@@ -148,7 +146,6 @@ models:
   labels:
   - validated
   - featured
-  - lab-base
 - type: oci
   uri: registry.redhat.io/rhelai1/modelcar-llama-3-1-nemotron-70b-instruct-hf-fp8-dynamic:1.5
   labels:


### PR DESCRIPTION
## Description
Remove deprecated 'lab-teacher' and 'lab-base' labels from model configurations in models-index.yaml and regenerated catalog. These labels are no longer used in the current model classification system.

Changes:
- Remove lab-teacher labels from llama-4-scout and mistral models
- Remove lab-base label from granite-3.1-8b-base model
- Update models-catalog.yaml to reflect label changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated model metadata to streamline labels.
  - Removed the “lab-teacher” label from RedHatAI/Llama-3-1-8B-Instruct and RedHatAI/Llama-3.1-Nemotron-70B-Instruct-HF.
  - Removed the “lab-base” label from RedHatAI/granite-3-1-8b-starter-v2 and granite-3-1-8b-base-quantized-w4a16:1.5.
  - These labels will no longer appear in listings, filters, or badges.
  - No model additions, removals, or URI/type changes; model availability and functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->