### PR TITLE
fix(enrichment): add RHAIIS preview serving runtime override for Mistral Small 4 models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,10 @@ Go application that extracts model metadata (model cards) from Red Hat AI ModelC
 - `make dev` - Quick development iteration (fmt, vet, test, build)
 - `make ci` - Full CI pipeline (deps, check, test, build)
 - `make process` - Process all model indexes and MCP server catalogs
-- `make process-models` - Process model indexes only (redhat, validated, other)
+- `make process-models` - Process all model indexes (redhat, validated, other)
+- `make process-redhat-models` - Process Red Hat models index only
+- `make process-validated-models` - Process validated models index only
+- `make process-other-models` - Process other models index only
 - `make process-redhat-mcp` - Process Red Hat MCP servers catalog only
 - `make docker-build` - Build Docker container image
 
@@ -203,3 +206,7 @@ See `pkg/utils/templates/tool-calling.md.tmpl` for the generated template.
 ## vLLM Recommended Configurations
 
 Optimized vLLM configurations from the PSAP team are stored as YAML files in `input/models/vllm-config/`. During enrichment, these are matched by exact `model.name` and rendered as a "vLLM Recommended Configurations" markdown section appended to the model's README. See `pkg/types/vllmconfig.go` for the YAML schema and `pkg/utils/templates/vllm-config.md.tmpl` for the template.
+
+## Serving Runtime Overrides
+
+When models require a preview or non-GA vLLM image (e.g., due to transformers library version requirements), override configuration is stored in `input/models/serving-runtime-override.yaml`. Models are selected by adding the `preview_serving_runtime_required` label in `data/validated-models-index.yaml`. During enrichment, two insertions are made to the model's README: a blockquote note (from the config's `note` field) is inserted right after the H1 title, and the deployment instructions section (rendered from `pkg/utils/templates/serving-runtime-override.md.tmpl`) is inserted before the first `##` heading. See `pkg/types/servingruntimeoverride.go` for the config struct.

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ DOCKER_IMAGE_NAME?=quay.io/opendatahub/odh-model-metadata-collection
 DOCKER_IMAGE_TAG?=latest
 DOCKER_FULL_IMAGE_NAME=$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
 
-.PHONY: all build build-report clean test test-coverage lint fmt vet deps check help run process process-models process-redhat-mcp process-partner-mcp process-community-mcp report run-with-report docker-build
+.PHONY: all build build-report clean test test-coverage lint fmt vet deps check help run process process-models process-redhat-models process-validated-models process-other-models process-redhat-mcp process-partner-mcp process-community-mcp report run-with-report docker-build
 
 # Default target
 all: check build
@@ -129,23 +129,34 @@ run: build
 	@echo "Running model extractor..."
 	./$(BUILD_DIR)/$(BINARY_NAME)
 
-# Process models with custom input/output paths
-process-models: build
-	@echo "Processing models..."
+# Process Red Hat models index
+process-redhat-models: build
+	@echo "Processing Red Hat models..."
 	./$(BUILD_DIR)/$(BINARY_NAME) \
 		--input $(REDHAT_MODELS_INDEX_PATH) \
 		--output-dir output/redhat \
 		--catalog-output $(REDHAT_CATALOG_OUTPUT_PATH)
+
+# Process validated models index
+process-validated-models: build
+	@echo "Processing validated models..."
 	./$(BUILD_DIR)/$(BINARY_NAME) \
 		--input $(VALIDATED_MODELS_INDEX_PATH) \
 		--output-dir output/validated \
 		--catalog-output $(VALIDATED_CATALOG_OUTPUT_PATH) \
 		--skip-default-static-catalog
+
+# Process other models index
+process-other-models: build
+	@echo "Processing other models..."
 	./$(BUILD_DIR)/$(BINARY_NAME) \
 		--input $(OTHER_MODELS_INDEX_PATH) \
 		--output-dir output/other \
 		--catalog-output $(OTHER_CATALOG_OUTPUT_PATH) \
 		--skip-default-static-catalog
+
+# Process all model indexes (redhat, validated, other)
+process-models: process-redhat-models process-validated-models process-other-models
 
 # Process Red Hat MCP servers with input/output paths
 process-redhat-mcp: build
@@ -256,7 +267,10 @@ help:
 	@echo "  check        - Run all checks (fmt-check, vet, lint)"
 	@echo "  run          - Run with default settings"
 	@echo "  process      - Process all model indexes and MCP server catalogs"
-	@echo "  process-models          - Process model indexes (redhat, validated, other)"
+	@echo "  process-models          - Process all model indexes (redhat, validated, other)"
+	@echo "  process-redhat-models   - Process Red Hat models index only"
+	@echo "  process-validated-models - Process validated models index only"
+	@echo "  process-other-models    - Process other models index only"
 	@echo "  process-redhat-mcp      - Process Red Hat MCP servers catalog"
 	@echo "  process-partner-mcp     - Process Partner MCP servers catalog"
 	@echo "  process-community-mcp   - Process Community MCP servers catalog"

--- a/cmd/model-extractor/main.go
+++ b/cmd/model-extractor/main.go
@@ -187,7 +187,7 @@ func main() {
 			}
 
 			log.Printf("Using HuggingFace index file: %s", hfIndexFile)
-			err := enrichment.EnrichMetadataFromHuggingFace(hfIndexFile, *modelsIndexPath, *outputDir, filepath.Join(*inputDir, "models", "vllm-config"))
+			err := enrichment.EnrichMetadataFromHuggingFace(hfIndexFile, *modelsIndexPath, *outputDir, filepath.Join(*inputDir, "models", "vllm-config"), filepath.Join(*inputDir, "models", "serving-runtime-override.yaml"))
 			if err != nil {
 				log.Printf("Warning: Failed to enrich metadata: %v", err)
 			}

--- a/data/validated-models-catalog.yaml
+++ b/data/validated-models-catalog.yaml
@@ -3654,7 +3654,7 @@ models:
         - **Registry Access**: Ensure your OpenShift cluster has a Pull Secret configured for `registry.redhat.io`.
         - **GPU Resources**: Since this is a `vllm-cuda` image, your cluster must have the NVIDIA GPU Operator installed and available nodes with GPUs.
 
-        ### Step 1: Create a Custom Serving Runtime
+        ### Create a Custom Serving Runtime
 
         The "Serving Runtime" is the template OpenShift AI uses to launch your model container.
 
@@ -4347,7 +4347,7 @@ models:
         - **Registry Access**: Ensure your OpenShift cluster has a Pull Secret configured for `registry.redhat.io`.
         - **GPU Resources**: Since this is a `vllm-cuda` image, your cluster must have the NVIDIA GPU Operator installed and available nodes with GPUs.
 
-        ### Step 1: Create a Custom Serving Runtime
+        ### Create a Custom Serving Runtime
 
         The "Serving Runtime" is the template OpenShift AI uses to launch your model container.
 

--- a/data/validated-models-catalog.yaml
+++ b/data/validated-models-catalog.yaml
@@ -3659,19 +3659,21 @@ models:
         The "Serving Runtime" is the template OpenShift AI uses to launch your model container.
 
         1. Log in to the OpenShift AI Dashboard.
-        2. Go to **Settings > Serving runtimes**.
+        2. Go to **Settings > Model resources and operations > Serving runtimes**.
         3. Click **Add serving runtime**.
-        4. Select **Single-model serving platform** and click **Start from scratch**.
+        4. Select **REST or gRPC API**.
+        5. Select **Generative AI model**.
+        6. Select **Start from scratch**.
         5. Paste the following YAML configuration, ensuring the `image` field matches your specific RHAIIS preview tag:
 
         ```yaml
         apiVersion: serving.kserve.io/v1alpha1
         kind: ServingRuntime
         metadata:
-          name: rhaiis-vllm-runtime
+          name: rhaiis-vllm-runtime-mistral4
           annotations:
             opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-            openshift.io/display-name: "RHAIIS vLLM Preview Runtime"
+            openshift.io/display-name: "RHAIIS vLLM Preview Runtime - Mistral 4"
         spec:
           supportedModelFormats:
             - name: vLLM
@@ -3679,7 +3681,8 @@ models:
               autoSelect: true
           containers:
             - name: kserve-container
-              image: registry.redhat.io/rhaiis-preview/vllm-cuda-rhel9:mistral-4-small
+              # Use the specific image from your request
+              image: registry.redhat.io/rhaii-preview/vllm-cuda-rhel9:mistral-4-small
               command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
               args:
                 - "--model=/mnt/models"
@@ -4349,19 +4352,21 @@ models:
         The "Serving Runtime" is the template OpenShift AI uses to launch your model container.
 
         1. Log in to the OpenShift AI Dashboard.
-        2. Go to **Settings > Serving runtimes**.
+        2. Go to **Settings > Model resources and operations > Serving runtimes**.
         3. Click **Add serving runtime**.
-        4. Select **Single-model serving platform** and click **Start from scratch**.
+        4. Select **REST or gRPC API**.
+        5. Select **Generative AI model**.
+        6. Select **Start from scratch**.
         5. Paste the following YAML configuration, ensuring the `image` field matches your specific RHAIIS preview tag:
 
         ```yaml
         apiVersion: serving.kserve.io/v1alpha1
         kind: ServingRuntime
         metadata:
-          name: rhaiis-vllm-runtime
+          name: rhaiis-vllm-runtime-mistral4
           annotations:
             opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
-            openshift.io/display-name: "RHAIIS vLLM Preview Runtime"
+            openshift.io/display-name: "RHAIIS vLLM Preview Runtime - Mistral 4"
         spec:
           supportedModelFormats:
             - name: vLLM
@@ -4369,7 +4374,8 @@ models:
               autoSelect: true
           containers:
             - name: kserve-container
-              image: registry.redhat.io/rhaiis-preview/vllm-cuda-rhel9:mistral-4-small
+              # Use the specific image from your request
+              image: registry.redhat.io/rhaii-preview/vllm-cuda-rhel9:mistral-4-small
               command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
               args:
                 - "--model=/mnt/models"

--- a/data/validated-models-catalog.yaml
+++ b/data/validated-models-catalog.yaml
@@ -3635,6 +3635,8 @@ models:
       readme: |-
         # Mistral Small 4 119B A6B
 
+        > **Note**: This model requires a Preview serving runtime for deployment in OpenShift AI 3.4
+
         Mistral Small 4 is a powerful hybrid model capable of acting as both a general instruction model and a reasoning model. It unifies the capabilities of three different model families—**Instruct**, **Reasoning** (previously called Magistral), and **Devstral**—into a single, unified model.
 
         With its multimodal capabilities, efficient architecture, and flexible mode switching, it is a powerful general-purpose model for any task. In a latency-optimized setup, Mistral Small 4 achieves a **40% reduction in end-to-end completion time**, and in a throughput-optimized setup, it handles **3x more requests per second** compared to Mistral Small 3.
@@ -3642,6 +3644,54 @@ models:
         To further improve efficiency you can either take advantages of:
         - Speculative decoding thanks to our trained eagle head [`mistralai/Mistral-Small-4-119B-2603-eagle`](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603-eagle).
         - 4 bit float precision quantization thanks to our NVFP4 checkpoint [`mistralai/Mistral-Small-4-119B-2603-NVFP4`](https://huggingface.co/mistralai/Mistral-Small-4-119B-2603-NVFP4).
+
+        ## Deploying with RHAIIS Preview Runtime
+
+        To deploy a model using the Red Hat AI Inference Server (RHAIIS) preview image on OpenShift AI, you need to create a Custom Serving Runtime. OpenShift AI doesn't include the RHAIIS tech-preview images in its default "out-of-the-box" runtimes, so you must manually point the platform to that specific `registry.redhat.io` image.
+
+        ### Prerequisites
+
+        - **Registry Access**: Ensure your OpenShift cluster has a Pull Secret configured for `registry.redhat.io`.
+        - **GPU Resources**: Since this is a `vllm-cuda` image, your cluster must have the NVIDIA GPU Operator installed and available nodes with GPUs.
+
+        ### Step 1: Create a Custom Serving Runtime
+
+        The "Serving Runtime" is the template OpenShift AI uses to launch your model container.
+
+        1. Log in to the OpenShift AI Dashboard.
+        2. Go to **Settings > Serving runtimes**.
+        3. Click **Add serving runtime**.
+        4. Select **Single-model serving platform** and click **Start from scratch**.
+        5. Paste the following YAML configuration, ensuring the `image` field matches your specific RHAIIS preview tag:
+
+        ```yaml
+        apiVersion: serving.kserve.io/v1alpha1
+        kind: ServingRuntime
+        metadata:
+          name: rhaiis-vllm-runtime
+          annotations:
+            opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+            openshift.io/display-name: "RHAIIS vLLM Preview Runtime"
+        spec:
+          supportedModelFormats:
+            - name: vLLM
+              version: "1"
+              autoSelect: true
+          containers:
+            - name: kserve-container
+              image: registry.redhat.io/rhaiis-preview/vllm-cuda-rhel9:mistral-4-small
+              command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
+              args:
+                - "--model=/mnt/models"
+                - "--port=8080"
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
+              env:
+                - name: HF_HOME
+                  value: /tmp/hf_cache
+        ```
+
 
         ## Key Features
 
@@ -4240,6 +4290,9 @@ models:
         model_type:
             metadataType: MetadataStringValue
             string_value: "generative"
+        preview_serving_runtime_required:
+            metadataType: MetadataStringValue
+            string_value: ""
         vLLM:
             metadataType: MetadataStringValue
             string_value: ""
@@ -4270,6 +4323,8 @@ models:
       readme: |-
         # Mistral Small 4 119B A6B NVFP4
 
+        > **Note**: This model requires a Preview serving runtime for deployment in OpenShift AI 3.4
+
         Mistral Small 4 is a powerful hybrid model capable of acting as both a general instruction model and a reasoning model. It unifies the capabilities of three different model families—**Instruct**, **Reasoning** (previously called Magistral), and **Devstral**—into a single, unified model.
 
         With its multimodal capabilities, efficient architecture, and flexible mode switching, it is a powerful general-purpose model for any task. In a latency-optimized setup, Mistral Small 4 achieves a **40% reduction in end-to-end completion time**, and in a throughput-optimized setup, it handles **3x more requests per second** compared to Mistral Small 3.
@@ -4279,6 +4334,54 @@ models:
         > It was created using [llm-compressor](https://github.com/vllm-project/llm-compressor) as part of a collaboration with teams from vLLM & Red Hat.
         > Special thanks goes out to Dipika Sikka.
         > We also would like to thank NVIDIA for their expertise and contributions to SGLang as well as vLLM to ensure kernel optimizations.
+
+        ## Deploying with RHAIIS Preview Runtime
+
+        To deploy a model using the Red Hat AI Inference Server (RHAIIS) preview image on OpenShift AI, you need to create a Custom Serving Runtime. OpenShift AI doesn't include the RHAIIS tech-preview images in its default "out-of-the-box" runtimes, so you must manually point the platform to that specific `registry.redhat.io` image.
+
+        ### Prerequisites
+
+        - **Registry Access**: Ensure your OpenShift cluster has a Pull Secret configured for `registry.redhat.io`.
+        - **GPU Resources**: Since this is a `vllm-cuda` image, your cluster must have the NVIDIA GPU Operator installed and available nodes with GPUs.
+
+        ### Step 1: Create a Custom Serving Runtime
+
+        The "Serving Runtime" is the template OpenShift AI uses to launch your model container.
+
+        1. Log in to the OpenShift AI Dashboard.
+        2. Go to **Settings > Serving runtimes**.
+        3. Click **Add serving runtime**.
+        4. Select **Single-model serving platform** and click **Start from scratch**.
+        5. Paste the following YAML configuration, ensuring the `image` field matches your specific RHAIIS preview tag:
+
+        ```yaml
+        apiVersion: serving.kserve.io/v1alpha1
+        kind: ServingRuntime
+        metadata:
+          name: rhaiis-vllm-runtime
+          annotations:
+            opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+            openshift.io/display-name: "RHAIIS vLLM Preview Runtime"
+        spec:
+          supportedModelFormats:
+            - name: vLLM
+              version: "1"
+              autoSelect: true
+          containers:
+            - name: kserve-container
+              image: registry.redhat.io/rhaiis-preview/vllm-cuda-rhel9:mistral-4-small
+              command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
+              args:
+                - "--model=/mnt/models"
+                - "--port=8080"
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
+              env:
+                - name: HF_HOME
+                  value: /tmp/hf_cache
+        ```
+
 
         ## Key Features
 
@@ -4692,6 +4795,9 @@ models:
         model_type:
             metadataType: MetadataStringValue
             string_value: "generative"
+        preview_serving_runtime_required:
+            metadataType: MetadataStringValue
+            string_value: ""
         vLLM:
             metadataType: MetadataStringValue
             string_value: ""

--- a/data/validated-models-catalog.yaml
+++ b/data/validated-models-catalog.yaml
@@ -3664,7 +3664,7 @@ models:
         4. Select **REST or gRPC API**.
         5. Select **Generative AI model**.
         6. Select **Start from scratch**.
-        5. Paste the following YAML configuration, ensuring the `image` field matches your specific RHAIIS preview tag:
+        7. Paste the following YAML configuration, ensuring the `image` field matches your specific RHAIIS preview tag:
 
         ```yaml
         apiVersion: serving.kserve.io/v1alpha1
@@ -4357,7 +4357,7 @@ models:
         4. Select **REST or gRPC API**.
         5. Select **Generative AI model**.
         6. Select **Start from scratch**.
-        5. Paste the following YAML configuration, ensuring the `image` field matches your specific RHAIIS preview tag:
+        7. Paste the following YAML configuration, ensuring the `image` field matches your specific RHAIIS preview tag:
 
         ```yaml
         apiVersion: serving.kserve.io/v1alpha1

--- a/data/validated-models-index.yaml
+++ b/data/validated-models-index.yaml
@@ -266,10 +266,12 @@ models:
   uri: registry.redhat.io/rhai/modelcar-mistral-small-4-119b-2603:3.0
   labels:
   - validated
+  - preview_serving_runtime_required
 - type: oci
   uri: registry.redhat.io/rhai/modelcar-mistral-small-4-119b-2603-nvfp4:3.0
   labels:
   - validated
+  - preview_serving_runtime_required
 - type: oci
   uri: registry.redhat.io/rhai/modelcar-sarvam-30b-fp8-dynamic:3.0
   labels:

--- a/input/models/serving-runtime-override.yaml
+++ b/input/models/serving-runtime-override.yaml
@@ -1,8 +1,8 @@
 ---
-preview_image: "registry.redhat.io/rhaiis-preview/vllm-cuda-rhel9:mistral-4-small"
+preview_image: "registry.redhat.io/rhaii-preview/vllm-cuda-rhel9:mistral-4-small"
 reason: >-
   Mistral Small 4 requires transformers v5 which is not available in the
   current vLLM image.
-runtime_name: "rhaiis-vllm-runtime"
-display_name: "RHAIIS vLLM Preview Runtime"
+runtime_name: "rhaiis-vllm-runtime-mistral4"
+display_name: "RHAIIS vLLM Preview Runtime - Mistral 4"
 note: "This model requires a Preview serving runtime for deployment in OpenShift AI 3.4"

--- a/input/models/serving-runtime-override.yaml
+++ b/input/models/serving-runtime-override.yaml
@@ -1,0 +1,8 @@
+---
+preview_image: "registry.redhat.io/rhaiis-preview/vllm-cuda-rhel9:mistral-4-small"
+reason: >-
+  Mistral Small 4 requires transformers v5 which is not available in the
+  current vLLM image.
+runtime_name: "rhaiis-vllm-runtime"
+display_name: "RHAIIS vLLM Preview Runtime"
+note: "This model requires a Preview serving runtime for deployment in OpenShift AI 3.4"

--- a/internal/config/servingruntimeoverride.go
+++ b/internal/config/servingruntimeoverride.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/opendatahub-io/model-metadata-collection/pkg/types"
+)
+
+// LoadServingRuntimeOverrideConfig reads a single serving runtime override
+// configuration file. Returns nil (not error) when configPath is empty.
+func LoadServingRuntimeOverrideConfig(configPath string) (*types.ServingRuntimeOverrideConfig, error) {
+	if configPath == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read serving runtime override config %s: %w", configPath, err)
+	}
+
+	var cfg types.ServingRuntimeOverrideConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse serving runtime override config %s: %w", configPath, err)
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid serving runtime override config %s: %w", configPath, err)
+	}
+
+	return &cfg, nil
+}

--- a/internal/config/servingruntimeoverride_test.go
+++ b/internal/config/servingruntimeoverride_test.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadServingRuntimeOverrideConfig(t *testing.T) {
+	t.Run("empty path returns nil", func(t *testing.T) {
+		cfg, err := LoadServingRuntimeOverrideConfig("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg != nil {
+			t.Fatal("expected nil config for empty path")
+		}
+	})
+
+	t.Run("nonexistent file returns error", func(t *testing.T) {
+		_, err := LoadServingRuntimeOverrideConfig("/nonexistent/file.yaml")
+		if err == nil {
+			t.Fatal("expected error for nonexistent file")
+		}
+	})
+
+	t.Run("invalid YAML returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "bad.yaml")
+		if err := os.WriteFile(path, []byte(":::not yaml"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		_, err := LoadServingRuntimeOverrideConfig(path)
+		if err == nil {
+			t.Fatal("expected error for invalid YAML")
+		}
+	})
+
+	t.Run("missing required fields returns error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "incomplete.yaml")
+		content := []byte("preview_image: \"registry.example.com/image:tag\"\n")
+		if err := os.WriteFile(path, content, 0644); err != nil {
+			t.Fatal(err)
+		}
+		_, err := LoadServingRuntimeOverrideConfig(path)
+		if err == nil {
+			t.Fatal("expected validation error for missing fields")
+		}
+	})
+
+	t.Run("valid config loads successfully", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "valid.yaml")
+		content := []byte(`---
+preview_image: "registry.example.com/vllm:preview"
+reason: "Requires transformers v5"
+runtime_name: "test-runtime"
+display_name: "Test Preview Runtime"
+note: "This model requires a Preview serving runtime"
+`)
+		if err := os.WriteFile(path, content, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		cfg, err := LoadServingRuntimeOverrideConfig(path)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg == nil {
+			t.Fatal("expected non-nil config")
+		}
+		if cfg.PreviewImage != "registry.example.com/vllm:preview" {
+			t.Errorf("PreviewImage = %q, want %q", cfg.PreviewImage, "registry.example.com/vllm:preview")
+		}
+		if cfg.Reason != "Requires transformers v5" {
+			t.Errorf("Reason = %q, want %q", cfg.Reason, "Requires transformers v5")
+		}
+		if cfg.RuntimeName != "test-runtime" {
+			t.Errorf("RuntimeName = %q, want %q", cfg.RuntimeName, "test-runtime")
+		}
+		if cfg.DisplayName != "Test Preview Runtime" {
+			t.Errorf("DisplayName = %q, want %q", cfg.DisplayName, "Test Preview Runtime")
+		}
+		if cfg.Note != "This model requires a Preview serving runtime" {
+			t.Errorf("Note = %q, want %q", cfg.Note, "This model requires a Preview serving runtime")
+		}
+	})
+}

--- a/internal/enrichment/enrichment.go
+++ b/internal/enrichment/enrichment.go
@@ -52,7 +52,7 @@ func extractModelFamily(normalizedName string) string {
 }
 
 // EnrichMetadataFromHuggingFace enriches registry model metadata using HuggingFace data
-func EnrichMetadataFromHuggingFace(hfIndexPath, modelsIndexPath, outputDir, vllmConfigDir string) error {
+func EnrichMetadataFromHuggingFace(hfIndexPath, modelsIndexPath, outputDir, vllmConfigDir, srtOverrideConfigPath string) error {
 	log.Println("Enriching registry model metadata with HuggingFace data...")
 
 	// Load HuggingFace models
@@ -80,6 +80,29 @@ func EnrichMetadataFromHuggingFace(hfIndexPath, modelsIndexPath, outputDir, vllm
 		log.Printf("Warning: Failed to load vLLM configs: %v", vllmErr)
 	} else {
 		log.Printf("Loaded %d vLLM recommended configurations", vllmIndex.ModelCount())
+	}
+
+	// Build label lookup map from full model entries (LoadModelsFromYAML drops labels)
+	modelEntries, labelErr := config.LoadModelsConfigFromYAML(modelsIndexPath)
+	labelMap := make(map[string][]string)
+	if labelErr != nil {
+		log.Printf("Warning: Failed to load model labels: %v", labelErr)
+	} else {
+		for _, entry := range modelEntries {
+			labelMap[entry.URI] = entry.Labels
+		}
+	}
+
+	// Load serving runtime override config (single file)
+	var srtOverrideConfig *types.ServingRuntimeOverrideConfig
+	if srtOverrideConfigPath != "" {
+		srtOverrideConfig, err = config.LoadServingRuntimeOverrideConfig(srtOverrideConfigPath)
+		if err != nil {
+			log.Printf("Warning: Failed to load serving runtime override config: %v", err)
+			srtOverrideConfig = nil
+		} else if srtOverrideConfig != nil {
+			log.Printf("Loaded serving runtime override config: %s", srtOverrideConfigPath)
+		}
 	}
 
 	matchCount := 0
@@ -289,6 +312,20 @@ func EnrichMetadataFromHuggingFace(hfIndexPath, modelsIndexPath, outputDir, vllm
 			if score > bestScore {
 				bestScore = score
 				bestMatch = hfModel
+			}
+		}
+
+		// Check if model has preview_serving_runtime_required label (unconditional —
+		// deployment override must apply even when HuggingFace matching fails)
+		if srtOverrideConfig != nil {
+			if labels, ok := labelMap[regModel]; ok {
+				for _, label := range labels {
+					if label == "preview_serving_runtime_required" {
+						enriched.ServingRuntimeOverride = srtOverrideConfig
+						log.Printf("  Model has preview_serving_runtime_required label: %s", regModel)
+						break
+					}
+				}
 			}
 		}
 
@@ -573,6 +610,14 @@ func EnrichMetadataFromHuggingFace(hfIndexPath, modelsIndexPath, outputDir, vllm
 			}
 
 			matchCount++
+		} else if enriched.ServingRuntimeOverride != nil {
+			// Model didn't match HuggingFace but has a serving runtime override label —
+			// still write metadata so the deployment instructions appear in the catalog
+			log.Printf("  No HuggingFace match but model has serving runtime override, writing metadata for: %s", regModel)
+			err = UpdateModelMetadataFile(regModel, &enriched, outputDir)
+			if err != nil {
+				log.Printf("  Warning: Failed to update metadata file for %s: %v", regModel, err)
+			}
 		}
 
 	}

--- a/internal/enrichment/enrichment_test.go
+++ b/internal/enrichment/enrichment_test.go
@@ -2,6 +2,7 @@ package enrichment
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -29,7 +30,7 @@ func TestEnrichMetadataFromHuggingFace_FilesNotExist(t *testing.T) {
 	}
 
 	// Test with missing HuggingFace index file
-	err = EnrichMetadataFromHuggingFace("nonexistent-hf.yaml", "nonexistent-models.yaml", "output", "")
+	err = EnrichMetadataFromHuggingFace("nonexistent-hf.yaml", "nonexistent-models.yaml", "output", "", "")
 	if err == nil {
 		t.Error("Expected error when HuggingFace index file doesn't exist")
 	}
@@ -68,7 +69,7 @@ func TestEnrichMetadataFromHuggingFace_InvalidHFFile(t *testing.T) {
 	}
 
 	// Test with invalid HuggingFace file
-	err = EnrichMetadataFromHuggingFace("nonexistent-hf.yaml", "nonexistent-models.yaml", "output", "")
+	err = EnrichMetadataFromHuggingFace("nonexistent-hf.yaml", "nonexistent-models.yaml", "output", "", "")
 	if err == nil {
 		t.Error("Expected error when HuggingFace index file is invalid")
 	}
@@ -122,7 +123,7 @@ func TestEnrichMetadataFromHuggingFace_MissingModelsIndex(t *testing.T) {
 	}
 
 	// Test with missing models-index.yaml
-	err = EnrichMetadataFromHuggingFace("nonexistent-hf.yaml", "nonexistent-models.yaml", "output", "")
+	err = EnrichMetadataFromHuggingFace("nonexistent-hf.yaml", "nonexistent-models.yaml", "output", "", "")
 	if err == nil {
 		t.Error("Expected error when models-index.yaml doesn't exist")
 	}
@@ -185,7 +186,7 @@ func TestEnrichMetadataFromHuggingFace_EmptyFiles(t *testing.T) {
 	}
 
 	// Test with empty files - should succeed
-	err = EnrichMetadataFromHuggingFace("data/hugging-face-redhat-ai-validated-v1-0.yaml", "data/models-index.yaml", "output", "")
+	err = EnrichMetadataFromHuggingFace("data/hugging-face-redhat-ai-validated-v1-0.yaml", "data/models-index.yaml", "output", "", "")
 	if err != nil {
 		t.Errorf("Unexpected error with empty files: %v", err)
 	}
@@ -373,6 +374,154 @@ func TestUpdateOCIArtifacts_InvalidModel(t *testing.T) {
 	err := UpdateOCIArtifacts("invalid-model-reference", "output")
 	if err == nil {
 		t.Error("Expected error for invalid model reference")
+	}
+}
+
+func TestInsertBeforeFirstSection(t *testing.T) {
+	section := "## Override Section\n\nOverride content here."
+
+	tests := []struct {
+		name          string
+		readme        string
+		expectedOrder []string
+	}{
+		{
+			name:   "with H1 heading only",
+			readme: "# Model Card\n\nSome description here.",
+			expectedOrder: []string{
+				"# Model Card",
+				"Some description here.",
+				"## Override Section",
+			},
+		},
+		{
+			name:   "without any heading",
+			readme: "Some readme without a heading.",
+			expectedOrder: []string{
+				"Some readme without a heading.",
+				"## Override Section",
+			},
+		},
+		{
+			name:   "empty readme",
+			readme: "",
+			expectedOrder: []string{
+				"## Override Section",
+			},
+		},
+		{
+			name:   "H1 heading with H2 section after",
+			readme: "# Title\n\nParagraph 1\n\n## Section 2\n\nParagraph 2",
+			expectedOrder: []string{
+				"# Title",
+				"Paragraph 1",
+				"## Override Section",
+				"## Section 2",
+			},
+		},
+		{
+			name:   "H2 heading only (no H1)",
+			readme: "## Not an H1\n\nContent",
+			expectedOrder: []string{
+				"## Override Section",
+				"## Not an H1",
+				"Content",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := insertBeforeFirstSection(tt.readme, section)
+
+			// Verify ordering of expected strings
+			lastIdx := -1
+			for _, expected := range tt.expectedOrder {
+				idx := strings.Index(result, expected)
+				if idx == -1 {
+					t.Errorf("Expected to find %q in result:\n%s", expected, result)
+					continue
+				}
+				if idx <= lastIdx {
+					t.Errorf("Expected %q to appear after previous expected string in result:\n%s", expected, result)
+				}
+				lastIdx = idx
+			}
+		})
+	}
+}
+
+func TestInsertNoteAfterH1(t *testing.T) {
+	note := "This model requires a Preview serving runtime for deployment in OpenShift AI 3.4"
+	expectedBlockquote := "> **Note**: " + note
+
+	tests := []struct {
+		name          string
+		readme        string
+		expectedOrder []string
+	}{
+		{
+			name:   "with H1 heading",
+			readme: "# Model Card\n\nSome description here.\n\n## Details",
+			expectedOrder: []string{
+				"# Model Card",
+				expectedBlockquote,
+				"Some description here.",
+				"## Details",
+			},
+		},
+		{
+			name:   "without any heading",
+			readme: "Some readme without a heading.",
+			expectedOrder: []string{
+				expectedBlockquote,
+				"Some readme without a heading.",
+			},
+		},
+		{
+			name:   "empty readme",
+			readme: "",
+			expectedOrder: []string{
+				expectedBlockquote,
+			},
+		},
+		{
+			name:   "H1 heading only",
+			readme: "# Title Only",
+			expectedOrder: []string{
+				"# Title Only",
+				expectedBlockquote,
+			},
+		},
+		{
+			name:   "H1 with multiple sections",
+			readme: "# Title\n\nIntro text\n\n## Section 1\n\nContent 1\n\n## Section 2",
+			expectedOrder: []string{
+				"# Title",
+				expectedBlockquote,
+				"Intro text",
+				"## Section 1",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := insertNoteAfterH1(tt.readme, note)
+
+			lastIdx := -1
+			for _, expected := range tt.expectedOrder {
+				idx := strings.Index(result, expected)
+				if idx == -1 {
+					t.Errorf("Expected to find %q in result:\n%s", expected, result)
+					continue
+				}
+				if idx <= lastIdx {
+					t.Errorf("Expected %q to appear after previous expected string in result:\n%s", expected, result)
+				}
+				lastIdx = idx
+			}
+		})
 	}
 }
 

--- a/internal/enrichment/update.go
+++ b/internal/enrichment/update.go
@@ -351,6 +351,41 @@ func UpdateModelMetadataFile(registryModel string, enrichedData *types.EnrichedM
 		}
 	}
 
+	// PREPEND serving runtime override section to README (before first ## heading)
+	// This goes BEFORE tool-calling and vLLM config sections since it's critical deployment info
+	// Guard against duplicate sections on re-enrichment runs
+	if enrichedData.ServingRuntimeOverride != nil {
+		alreadyPresent := existingMetadata.Readme != nil && strings.Contains(*existingMetadata.Readme, "## Deploying with RHAIIS Preview Runtime")
+		if alreadyPresent {
+			log.Printf("  Serving runtime override already present in README, skipping for: %s", registryModel)
+		} else {
+			srtSection, err := utils.RenderServingRuntimeOverrideSection(enrichedData.ServingRuntimeOverride)
+			if err != nil {
+				log.Printf("  Warning: Failed to render serving runtime override section for %s: %v", registryModel, err)
+			} else if srtSection != "" {
+				if existingMetadata.Readme == nil {
+					existingMetadata.Readme = &srtSection
+					log.Printf("  Created README with serving runtime override section for: %s", registryModel)
+				} else {
+					updatedReadme := insertBeforeFirstSection(*existingMetadata.Readme, srtSection)
+					existingMetadata.Readme = &updatedReadme
+					log.Printf("  Prepended serving runtime override section to README for: %s", registryModel)
+				}
+
+				// Insert note blockquote right after H1 heading (if configured)
+				// Only inserted when the override section was successfully rendered above
+				if enrichedData.ServingRuntimeOverride.Note != "" && existingMetadata.Readme != nil {
+					noteBlockquote := "> **Note**: " + enrichedData.ServingRuntimeOverride.Note
+					if !strings.Contains(*existingMetadata.Readme, noteBlockquote) {
+						updatedReadme := insertNoteAfterH1(*existingMetadata.Readme, enrichedData.ServingRuntimeOverride.Note)
+						existingMetadata.Readme = &updatedReadme
+						log.Printf("  Inserted serving runtime override note after title for: %s", registryModel)
+					}
+				}
+			}
+		}
+	}
+
 	// Append tool-calling section to README ONLY if tool-calling config exists
 	// Section is NOT added when ToolCallingConfig is nil or HasToolCalling() returns false
 	// Guard against duplicate sections on re-enrichment runs
@@ -448,4 +483,46 @@ func UpdateModelMetadataFile(registryModel string, enrichedData *types.EnrichedM
 	}
 
 	return nil
+}
+
+// insertNoteAfterH1 inserts a blockquote note right after the first H1 heading line.
+// If no H1 heading is found, the note is prepended at the very top.
+func insertNoteAfterH1(readme, note string) string {
+	blockquote := "> **Note**: " + note
+	lines := strings.Split(readme, "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, "# ") {
+			before := strings.Join(lines[:i+1], "\n")
+			after := strings.TrimLeft(strings.Join(lines[i+1:], "\n"), "\n")
+			if after == "" {
+				return before + "\n\n" + blockquote
+			}
+			return before + "\n\n" + blockquote + "\n\n" + after
+		}
+	}
+	// No H1 heading found, prepend at the top
+	if readme == "" {
+		return blockquote
+	}
+	return blockquote + "\n\n" + readme
+}
+
+// insertBeforeFirstSection inserts section before the first ## heading in readme,
+// keeping any title and introductory text intact above the insertion point.
+// If no ## heading is found, the section is appended at the end.
+func insertBeforeFirstSection(readme, section string) string {
+	lines := strings.Split(readme, "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, "## ") {
+			// Insert section before this ## heading
+			before := strings.TrimRight(strings.Join(lines[:i], "\n"), "\n")
+			after := strings.Join(lines[i:], "\n")
+			if before == "" {
+				return section + "\n\n" + after
+			}
+			return before + "\n\n" + section + "\n\n" + after
+		}
+	}
+	// No ## heading found, append at the end
+	return strings.TrimRight(readme, "\n") + "\n\n" + section
 }

--- a/pkg/types/servingruntimeoverride.go
+++ b/pkg/types/servingruntimeoverride.go
@@ -1,0 +1,30 @@
+package types
+
+import "fmt"
+
+// ServingRuntimeOverrideConfig holds configuration for models that require
+// a custom (preview) serving runtime image instead of the default GA image.
+type ServingRuntimeOverrideConfig struct {
+	PreviewImage string `yaml:"preview_image"`
+	Reason       string `yaml:"reason,omitempty"` // documentation-only: why this override is needed
+	RuntimeName  string `yaml:"runtime_name"`
+	DisplayName  string `yaml:"display_name"`
+	Note         string `yaml:"note,omitempty"`
+}
+
+// Validate checks that all required fields are present.
+func (c *ServingRuntimeOverrideConfig) Validate() error {
+	if c == nil {
+		return fmt.Errorf("config is nil")
+	}
+	if c.PreviewImage == "" {
+		return fmt.Errorf("preview_image is required")
+	}
+	if c.RuntimeName == "" {
+		return fmt.Errorf("runtime_name is required")
+	}
+	if c.DisplayName == "" {
+		return fmt.Errorf("display_name is required")
+	}
+	return nil
+}

--- a/pkg/types/servingruntimeoverride_test.go
+++ b/pkg/types/servingruntimeoverride_test.go
@@ -1,0 +1,68 @@
+package types
+
+import "testing"
+
+func TestServingRuntimeOverrideConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *ServingRuntimeOverrideConfig
+		wantErr bool
+	}{
+		{
+			name:    "nil config",
+			config:  nil,
+			wantErr: true,
+		},
+		{
+			name:    "empty config",
+			config:  &ServingRuntimeOverrideConfig{},
+			wantErr: true,
+		},
+		{
+			name: "missing preview_image",
+			config: &ServingRuntimeOverrideConfig{
+				Reason:      "test reason",
+				RuntimeName: "test-runtime",
+				DisplayName: "Test Runtime",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing runtime_name",
+			config: &ServingRuntimeOverrideConfig{
+				PreviewImage: "registry.example.com/image:tag",
+				Reason:       "test reason",
+				DisplayName:  "Test Runtime",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing display_name",
+			config: &ServingRuntimeOverrideConfig{
+				PreviewImage: "registry.example.com/image:tag",
+				Reason:       "test reason",
+				RuntimeName:  "test-runtime",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid config",
+			config: &ServingRuntimeOverrideConfig{
+				PreviewImage: "registry.example.com/image:tag",
+				Reason:       "test reason",
+				RuntimeName:  "test-runtime",
+				DisplayName:  "Test Runtime",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -162,6 +162,9 @@ type EnrichedModelMetadata struct {
 	// vLLM recommended configuration (not exported to YAML, used during enrichment only)
 	VLLMConfig *VLLMRecommendedConfig `yaml:"-"`
 
+	// Serving runtime override (not exported to YAML, used during enrichment only)
+	ServingRuntimeOverride *ServingRuntimeOverrideConfig `yaml:"-"`
+
 	// README content from HuggingFace (not exported to YAML, used during enrichment only)
 	ReadmeContent string `yaml:"-"`
 

--- a/pkg/utils/template.go
+++ b/pkg/utils/template.go
@@ -162,3 +162,31 @@ func RenderVLLMConfigSection(config *types.VLLMRecommendedConfig) (string, error
 
 	return buf.String(), nil
 }
+
+// RenderServingRuntimeOverrideSection renders the serving runtime override section
+// Returns empty string if config is nil
+func RenderServingRuntimeOverrideSection(config *types.ServingRuntimeOverrideConfig) (string, error) {
+	if config == nil {
+		return "", nil
+	}
+
+	if templateInitError != nil {
+		return "", fmt.Errorf("templates failed to initialize: %w", templateInitError)
+	}
+
+	if templateCache == nil {
+		return "", fmt.Errorf("template cache not initialized")
+	}
+
+	tmpl := templateCache.Lookup("serving-runtime-override.md.tmpl")
+	if tmpl == nil {
+		return "", fmt.Errorf("serving-runtime-override template not found in cache")
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, config); err != nil {
+		return "", fmt.Errorf("failed to render serving-runtime-override template: %w", err)
+	}
+
+	return buf.String(), nil
+}

--- a/pkg/utils/template_test.go
+++ b/pkg/utils/template_test.go
@@ -440,6 +440,65 @@ func TestRenderVLLMConfigSection_MinimalConfig(t *testing.T) {
 	}
 }
 
+func TestRenderServingRuntimeOverrideSection_NoConfig(t *testing.T) {
+	got, err := RenderServingRuntimeOverrideSection(nil)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+	if got != "" {
+		t.Errorf("Expected empty string for nil config, got: %q", got)
+	}
+}
+
+func TestRenderServingRuntimeOverrideSection_FullConfig(t *testing.T) {
+	config := &types.ServingRuntimeOverrideConfig{
+		PreviewImage: "registry.redhat.io/rhaiis-preview/vllm-cuda-rhel9:mistral-4-small",
+		Reason:       "Requires transformers v5",
+		RuntimeName:  "rhaiis-vllm-runtime",
+		DisplayName:  "RHAIIS vLLM Preview Runtime",
+	}
+
+	got, err := RenderServingRuntimeOverrideSection(config)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	expectedPhrases := []string{
+		"## Deploying with RHAIIS Preview Runtime",
+		"Custom Serving Runtime",
+		"registry.redhat.io",
+		"Pull Secret",
+		"NVIDIA GPU Operator",
+		"OpenShift AI Dashboard",
+		"Settings > Serving runtimes",
+		"Add serving runtime",
+		"Single-model serving platform",
+		"rhaiis-vllm-runtime",
+		"RHAIIS vLLM Preview Runtime",
+		"registry.redhat.io/rhaiis-preview/vllm-cuda-rhel9:mistral-4-small",
+		"vllm.entrypoints.openai.api_server",
+		"--model=/mnt/models",
+		"--port=8080",
+		"HF_HOME",
+	}
+
+	for _, phrase := range expectedPhrases {
+		if !strings.Contains(got, phrase) {
+			t.Errorf("Output missing expected phrase: %q", phrase)
+		}
+	}
+
+	// Verify YAML code block
+	if !strings.Contains(got, "```yaml") {
+		t.Error("Output missing YAML code block")
+	}
+
+	// Verify ServingRuntime kind
+	if !strings.Contains(got, "kind: ServingRuntime") {
+		t.Error("Output missing ServingRuntime kind")
+	}
+}
+
 func TestTitleCase(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/pkg/utils/template_test.go
+++ b/pkg/utils/template_test.go
@@ -454,8 +454,8 @@ func TestRenderServingRuntimeOverrideSection_FullConfig(t *testing.T) {
 	config := &types.ServingRuntimeOverrideConfig{
 		PreviewImage: "registry.redhat.io/rhaiis-preview/vllm-cuda-rhel9:mistral-4-small",
 		Reason:       "Requires transformers v5",
-		RuntimeName:  "rhaiis-vllm-runtime",
-		DisplayName:  "RHAIIS vLLM Preview Runtime",
+		RuntimeName:  "rhaiis-vllm-runtime-mistral4",
+		DisplayName:  "RHAIIS vLLM Preview Runtime - Mistral 4",
 	}
 
 	got, err := RenderServingRuntimeOverrideSection(config)
@@ -470,11 +470,12 @@ func TestRenderServingRuntimeOverrideSection_FullConfig(t *testing.T) {
 		"Pull Secret",
 		"NVIDIA GPU Operator",
 		"OpenShift AI Dashboard",
-		"Settings > Serving runtimes",
+		"Settings > Model resources and operations > Serving runtimes",
 		"Add serving runtime",
-		"Single-model serving platform",
-		"rhaiis-vllm-runtime",
-		"RHAIIS vLLM Preview Runtime",
+		"REST or gRPC API",
+		"Generative AI model",
+		"rhaiis-vllm-runtime-mistral4",
+		"RHAIIS vLLM Preview Runtime - Mistral 4",
 		"registry.redhat.io/rhaiis-preview/vllm-cuda-rhel9:mistral-4-small",
 		"vllm.entrypoints.openai.api_server",
 		"--model=/mnt/models",

--- a/pkg/utils/templates/serving-runtime-override.md.tmpl
+++ b/pkg/utils/templates/serving-runtime-override.md.tmpl
@@ -1,0 +1,46 @@
+## Deploying with RHAIIS Preview Runtime
+
+To deploy a model using the Red Hat AI Inference Server (RHAIIS) preview image on OpenShift AI, you need to create a Custom Serving Runtime. OpenShift AI doesn't include the RHAIIS tech-preview images in its default "out-of-the-box" runtimes, so you must manually point the platform to that specific `registry.redhat.io` image.
+
+### Prerequisites
+
+- **Registry Access**: Ensure your OpenShift cluster has a Pull Secret configured for `registry.redhat.io`.
+- **GPU Resources**: Since this is a `vllm-cuda` image, your cluster must have the NVIDIA GPU Operator installed and available nodes with GPUs.
+
+### Step 1: Create a Custom Serving Runtime
+
+The "Serving Runtime" is the template OpenShift AI uses to launch your model container.
+
+1. Log in to the OpenShift AI Dashboard.
+2. Go to **Settings > Serving runtimes**.
+3. Click **Add serving runtime**.
+4. Select **Single-model serving platform** and click **Start from scratch**.
+5. Paste the following YAML configuration, ensuring the `image` field matches your specific RHAIIS preview tag:
+
+```yaml
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  name: {{ .RuntimeName }}
+  annotations:
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+    openshift.io/display-name: "{{ .DisplayName }}"
+spec:
+  supportedModelFormats:
+    - name: vLLM
+      version: "1"
+      autoSelect: true
+  containers:
+    - name: kserve-container
+      image: {{ .PreviewImage }}
+      command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
+      args:
+        - "--model=/mnt/models"
+        - "--port=8080"
+      ports:
+        - containerPort: 8080
+          protocol: TCP
+      env:
+        - name: HF_HOME
+          value: /tmp/hf_cache
+```

--- a/pkg/utils/templates/serving-runtime-override.md.tmpl
+++ b/pkg/utils/templates/serving-runtime-override.md.tmpl
@@ -12,9 +12,11 @@ To deploy a model using the Red Hat AI Inference Server (RHAIIS) preview image o
 The "Serving Runtime" is the template OpenShift AI uses to launch your model container.
 
 1. Log in to the OpenShift AI Dashboard.
-2. Go to **Settings > Serving runtimes**.
+2. Go to **Settings > Model resources and operations > Serving runtimes**.
 3. Click **Add serving runtime**.
-4. Select **Single-model serving platform** and click **Start from scratch**.
+4. Select **REST or gRPC API**.
+5. Select **Generative AI model**.
+6. Select **Start from scratch**.
 5. Paste the following YAML configuration, ensuring the `image` field matches your specific RHAIIS preview tag:
 
 ```yaml
@@ -32,6 +34,7 @@ spec:
       autoSelect: true
   containers:
     - name: kserve-container
+      # Use the specific image from your request
       image: {{ .PreviewImage }}
       command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
       args:

--- a/pkg/utils/templates/serving-runtime-override.md.tmpl
+++ b/pkg/utils/templates/serving-runtime-override.md.tmpl
@@ -17,7 +17,7 @@ The "Serving Runtime" is the template OpenShift AI uses to launch your model con
 4. Select **REST or gRPC API**.
 5. Select **Generative AI model**.
 6. Select **Start from scratch**.
-5. Paste the following YAML configuration, ensuring the `image` field matches your specific RHAIIS preview tag:
+7. Paste the following YAML configuration, ensuring the `image` field matches your specific RHAIIS preview tag:
 
 ```yaml
 apiVersion: serving.kserve.io/v1alpha1

--- a/pkg/utils/templates/serving-runtime-override.md.tmpl
+++ b/pkg/utils/templates/serving-runtime-override.md.tmpl
@@ -7,7 +7,7 @@ To deploy a model using the Red Hat AI Inference Server (RHAIIS) preview image o
 - **Registry Access**: Ensure your OpenShift cluster has a Pull Secret configured for `registry.redhat.io`.
 - **GPU Resources**: Since this is a `vllm-cuda` image, your cluster must have the NVIDIA GPU Operator installed and available nodes with GPUs.
 
-### Step 1: Create a Custom Serving Runtime
+### Create a Custom Serving Runtime
 
 The "Serving Runtime" is the template OpenShift AI uses to launch your model container.
 


### PR DESCRIPTION
## Description
RHOAIENG-58258: Temporary fix for 3.4 release (to be removed in 3.5). Mistral Small 4 models require transformers v5 which is not available in the GA RHAIIS image.

- Add serving runtime override feature that inserts RHAIIS preview runtime deployment instructions and a note blockquote into the README for models labeled `preview_serving_runtime_required` in the validated models index
- Split Makefile `process-models` into independent per-index targets (`process-redhat-models`, `process-validated-models`, `process-other-models`)

## How Has This Been Tested?
- Unit tests
- Validation of output file

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Serving runtime override support for preview models and per-category model processing (Red Hat, validated, other) via new processing targets.

* **Documentation**
  * READMEs now get a blockquote note after the H1 and a deployment instructions section before the first section; added serving-runtime override docs and preview runtime guidance for Mistral Small 4.

* **Tests**
  * Added tests covering override config validation/loading, markdown insertion helpers, and template rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->