### PR TITLE
fix(mcp): update terraform-mcp-server provider to IBM Terraform

### DIFF
--- a/data/partner-mcp-servers-catalog.yaml
+++ b/data/partner-mcp-servers-catalog.yaml
@@ -410,7 +410,7 @@ mcp_servers:
             string_value: "[\"amd64\"]"
       lastUpdateTimeSinceEpoch: "1773865179000"
     - name: hashicorp/terraform-mcp-server
-      provider: HashiCorp
+      provider: IBM Terraform
       license: MPL-2.0
       license_link: https://www.mozilla.org/en-US/MPL/2.0/
       description: 'Gain real-time access to current Terraform provider documentation, modules, and policies from the Terraform registry. Supports HCP Terraform and Terraform Enterprise workspace management. NOTE: Beta software - do not use in production environments.'

--- a/input/mcp_servers/partner/hashicorp-terraform-mcp-server.yaml
+++ b/input/mcp_servers/partner/hashicorp-terraform-mcp-server.yaml
@@ -1,5 +1,5 @@
 name: hashicorp/terraform-mcp-server
-provider: HashiCorp
+provider: IBM Terraform
 license: MPL-2.0
 license_link: https://www.mozilla.org/en-US/MPL/2.0/
 description: 'Gain real-time access to current Terraform provider documentation, modules, and policies from the Terraform registry. Supports HCP Terraform and Terraform Enterprise workspace management. NOTE: Beta software - do not use in production environments.'


### PR DESCRIPTION
## Description
Update the provider attribution for hashicorp/terraform-mcp-server from HashiCorp to IBM Terraform in both the input definition and generated catalog.

## How Has This Been Tested?
Unit tests
Output validation

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated provider attribution for the Terraform MCP server from HashiCorp to IBM Terraform in the server catalog and configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->