### PR TITLE
chore: remove granite-3-1-8b-starter-v2

### DIFF
--- a/data/validated-models-catalog.yaml
+++ b/data/validated-models-catalog.yaml
@@ -7075,13 +7075,10 @@ models:
       licenseLink: https://www.apache.org/licenses/LICENSE-2.0
       tasks:
         - text-to-text
-      createTimeSinceEpoch: "1739776988000"
+      createTimeSinceEpoch: "1754345689000"
       lastUpdateTimeSinceEpoch: "1769070167000"
       customProperties:
         conversational:
-            metadataType: MetadataStringValue
-            string_value: ""
-        featured:
             metadataType: MetadataStringValue
             string_value: ""
         granite:
@@ -7113,19 +7110,6 @@ models:
             architecture:
                 metadataType: MetadataStringValue
                 string_value: '["amd64","arm64","ppc64le"]'
-            source:
-                metadataType: MetadataStringValue
-                string_value: registry.redhat.io
-            type:
-                metadataType: MetadataStringValue
-                string_value: modelcar
-        - uri: oci://registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-starter-v2:1.5
-          createTimeSinceEpoch: "1739776988000"
-          lastUpdateTimeSinceEpoch: "1747377277000"
-          customProperties:
-            architecture:
-                metadataType: MetadataStringValue
-                string_value: '["amd64"]'
             source:
                 metadataType: MetadataStringValue
                 string_value: registry.redhat.io

--- a/data/validated-models-index.yaml
+++ b/data/validated-models-index.yaml
@@ -174,11 +174,6 @@ models:
   labels:
   - validated
 - type: oci
-  uri: registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-starter-v2:1.5
-  labels:
-  - validated
-  - featured
-- type: oci
   uri: registry.redhat.io/rhelai1/modelcar-gpt-oss-120b:1.5
   labels:
   - validated


### PR DESCRIPTION
## Description
Remove the `modelcar-granite-3-1-8b-starter-v2` image

## How Has This Been Tested?
Rebuilt metadata and manually confirmed the duplicate image is gone.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a model variant entry from the validated models index
  * Updated model catalog metadata and removed associated featured designation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->