### PR TITLE
chore(catalog): refresh validated models catalog with latest upstream metadata

### DIFF
--- a/data/validated-models-catalog.yaml
+++ b/data/validated-models-catalog.yaml
@@ -347,7 +347,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-llama-3-1-8b-instruct:1.5
           createTimeSinceEpoch: "1754345689000"
@@ -399,7 +399,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-llama-3-1-nemotron-70b-instruct-hf:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -451,7 +451,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -516,7 +516,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-llama-3-3-70b-instruct:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -587,7 +587,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-llama-3-3-70b-instruct-fp8-dynamic:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -664,7 +664,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -1325,7 +1325,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -1395,7 +1395,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-llama-4-maverick-17b-128e-instruct:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -1481,7 +1481,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-llama-4-maverick-17b-128e-instruct-fp8:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -1549,7 +1549,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-llama-4-scout-17b-16e-instruct:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -1629,7 +1629,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-llama-4-scout-17b-16e-instruct-fp8-dynamic:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -1717,7 +1717,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-llama-4-scout-17b-16e-instruct-quantized-w4a16:1.5
           createTimeSinceEpoch: "1754345689000"
@@ -2253,7 +2253,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -2339,7 +2339,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -2422,7 +2422,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -2760,7 +2760,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -2828,7 +2828,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -3119,7 +3119,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -3193,7 +3193,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -3285,7 +3285,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-mistral-small-3-1-24b-instruct-2503:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -3392,7 +3392,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-mistral-small-3-1-24b-instruct-2503-fp8-dynamic:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -3502,7 +3502,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-mistral-small-3-1-24b-instruct-2503-quantized-w4a16:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -3609,7 +3609,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-mistral-small-3-1-24b-instruct-2503-quantized-w8a8:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -4229,7 +4229,14 @@ models:
         - bn
       license: apache-2.0
       licenseLink: https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/apache-2.0.md
-      tasks: []
+      tasks:
+        - tool-calling
+      servingConfig:
+        toolCalling:
+            toolCallParser: mistral
+            enableAutoToolChoice: true
+            requiredArgs:
+                - --reasoning-parser mistral
       createTimeSinceEpoch: "1754345689000"
       lastUpdateTimeSinceEpoch: "1773885235000"
       customProperties:
@@ -4752,7 +4759,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -4967,6 +4974,13 @@ models:
         - image-to-text
         - reasoning
         - tool-calling
+      servingConfig:
+        toolCalling:
+            toolCallParser: openai
+            enableAutoToolChoice: true
+            requiredArgs:
+                - --reasoning-parser nemotron_v3
+                - --tool-call-parser qwen3_coder
       createTimeSinceEpoch: "1754345689000"
       lastUpdateTimeSinceEpoch: "1774208956000"
       customProperties:
@@ -5287,7 +5301,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-qwen2-5-7b-instruct:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -5379,7 +5393,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-qwen2-5-7b-instruct-fp8-dynamic:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -5468,7 +5482,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -5793,7 +5807,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -6394,7 +6408,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-gemma-2-9b-it:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -6649,7 +6663,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -7052,7 +7066,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -7124,7 +7138,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-instruct:1.5
           createTimeSinceEpoch: "1754345689000"
@@ -7197,7 +7211,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -7249,7 +7263,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -7301,7 +7315,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
         vllm:
             metadataType: MetadataStringValue
             string_value: ""
@@ -7479,7 +7493,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-phi-4:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -7555,7 +7569,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-phi-4-fp8-dynamic:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -7635,7 +7649,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-phi-4-quantized-w4a16:1.5
           createTimeSinceEpoch: "1739776988000"
@@ -7714,7 +7728,7 @@ models:
             string_value: ""
         validated_on:
             metadataType: MetadataStringValue
-            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\"]"
+            string_value: "[\"RHOAI 2.20\",\"RHAIIS 3.0\",\"RHELAI 1.5\",\"vLLM 0.8.4\"]"
       artifacts:
         - uri: oci://registry.redhat.io/rhelai1/modelcar-phi-4-quantized-w8a8:1.5
           createTimeSinceEpoch: "1739776988000"


### PR DESCRIPTION
## Description
Update validated-models-catalog.yaml from upstream sources:
- Add vLLM 0.8.4 to validated_on platforms across 40 models
- Add structured tool-calling servingConfig for Mistral Small 3.2 24B (mistral parser) and Nemotron (openai parser with nemotron_v3 reasoning parser)

## How Has This Been Tested?
Validate output file

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tool-calling capabilities for AI models with configurable parser support.

* **Updates**
  * Extended model validation metadata to include vLLM 0.8.4 compatibility.
  * Updated model serving configurations with additional parser options for enhanced tool-calling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->