### PR TITLE
fix(catalog): remove incorrect starter-v2 modelcar artifact from granite-3.1-8b-instruct

### DIFF
--- a/data/validated-models-catalog.yaml
+++ b/data/validated-models-catalog.yaml
@@ -7109,13 +7109,10 @@ models:
       licenseLink: https://www.apache.org/licenses/LICENSE-2.0
       tasks:
         - text-to-text
-      createTimeSinceEpoch: "1739776988000"
+      createTimeSinceEpoch: "1754345689000"
       lastUpdateTimeSinceEpoch: "1769070167000"
       customProperties:
         conversational:
-            metadataType: MetadataStringValue
-            string_value: ""
-        featured:
             metadataType: MetadataStringValue
             string_value: ""
         granite:
@@ -7147,19 +7144,6 @@ models:
             architecture:
                 metadataType: MetadataStringValue
                 string_value: '["amd64","arm64","ppc64le"]'
-            source:
-                metadataType: MetadataStringValue
-                string_value: registry.redhat.io
-            type:
-                metadataType: MetadataStringValue
-                string_value: modelcar
-        - uri: oci://registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-starter-v2:1.5
-          createTimeSinceEpoch: "1739776988000"
-          lastUpdateTimeSinceEpoch: "1747377277000"
-          customProperties:
-            architecture:
-                metadataType: MetadataStringValue
-                string_value: '["amd64"]'
             source:
                 metadataType: MetadataStringValue
                 string_value: registry.redhat.io

--- a/data/validated-models-index.yaml
+++ b/data/validated-models-index.yaml
@@ -174,11 +174,6 @@ models:
   labels:
   - validated
 - type: oci
-  uri: registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-starter-v2:1.5
-  labels:
-  - validated
-  - featured
-- type: oci
   uri: registry.redhat.io/rhelai1/modelcar-gpt-oss-120b:1.5
   labels:
   - validated


### PR DESCRIPTION
## Description
The granite-3.1-8b-instruct model in the validated models catalog had an incorrectly associated starter-v2 modelcar artifact (modelcar-granite-3-1-8b-starter-v2:1.5). This commit removes the errant starter-v2 entry from the validated models index and catalog, removes the incorrectly inherited "featured" custom property, and corrects the createTimeSinceEpoch to match the actual modelcar-granite-3-1-8b-instruct image.

Ref: RHOAIENG-62675

## How Has This Been Tested?
Validated output files

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model catalog metadata with timestamp adjustments and removed associated custom properties for one entry.
  * Removed an OCI model entry and its validation labels from the models index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->