### PR TITLE
chore(catalog): refresh validated models catalog with latest upstream metadata

### DIFF
--- a/data/validated-models-catalog.yaml
+++ b/data/validated-models-catalog.yaml
@@ -4231,6 +4231,8 @@ models:
       licenseLink: https://huggingface.co/datasets/choosealicense/licenses/blob/main/markdown/apache-2.0.md
       tasks:
         - tool-calling
+      validatedTasks:
+        - tool-calling
       servingConfig:
         toolCalling:
             toolCallParser: mistral
@@ -4973,6 +4975,8 @@ models:
         - text-generation
         - image-to-text
         - reasoning
+        - tool-calling
+      validatedTasks:
         - tool-calling
       servingConfig:
         toolCalling:
@@ -6926,6 +6930,8 @@ models:
         - text-to-text
         - text-generation
         - tool-calling
+      validatedTasks:
+        - tool-calling
       servingConfig:
         toolCalling:
             toolCallParser: openai
@@ -6986,6 +6992,8 @@ models:
       tasks:
         - text-to-text
         - text-generation
+        - tool-calling
+      validatedTasks:
         - tool-calling
       servingConfig:
         toolCalling:


### PR DESCRIPTION
## Description
Populate validatedTasks for models with tool-calling support now that the validated-tasks vs validated_tasks YAML key mismatch has been resolved in the upstream HuggingFace READMEs. Affected models: NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4, Qwen2.5-Coder-7B-Instruct, Mistral-7B-Instruct-v0.3, and Qwen2.5-VL-7B-Instruct.

## How Has This Been Tested?
Valdiate output files

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model catalog entries to include validated task metadata for tool-calling capabilities across multiple model configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->