### PR TITLE
feat(catalog): add agent starter kit metadata pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,12 +185,14 @@ process-community-mcp: build
 	  	--skip-huggingface --skip-enrichment --skip-catalog
 
 # Process Red Hat agents catalog (fetches metadata from GitHub)
+# Set SKIP_AGENT_ENRICHMENT=true for offline runs (skips GitHub API calls)
 process-agents: build
 	@echo "Processing Red Hat agents catalog..."
 	./$(BUILD_DIR)/$(BINARY_NAME) \
-	  	--agent-index $(REDHAT_AGENTS_INDEX_PATH) \
-	  	--agent-catalog-output $(REDHAT_AGENTS_CATALOG_OUTPUT_PATH) \
-	  	--skip-huggingface --skip-enrichment --skip-catalog
+	  	--agent-index "$(REDHAT_AGENTS_INDEX_PATH)" \
+	  	--agent-catalog-output "$(REDHAT_AGENTS_CATALOG_OUTPUT_PATH)" \
+	  	--skip-huggingface --skip-enrichment --skip-catalog \
+	  	$(if $(filter true,$(SKIP_AGENT_ENRICHMENT)),--skip-agent-enrichment)
 
 # Process all model indexes, MCP server catalogs, and agent catalogs
 process: process-models process-redhat-mcp process-partner-mcp process-community-mcp process-agents

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ PARTNER_MCP_SERVERS_INDEX_PATH=data/partner-mcp-servers-index.yaml
 PARTNER_MCP_SERVERS_CATALOG_OUTPUT_PATH=data/partner-mcp-servers-catalog.yaml
 COMMUNITY_MCP_SERVERS_INDEX_PATH=data/community-mcp-servers-index.yaml
 COMMUNITY_MCP_SERVERS_CATALOG_OUTPUT_PATH=data/community-mcp-servers-catalog.yaml
+REDHAT_AGENTS_INDEX_PATH=data/redhat-agents-index.yaml
+REDHAT_AGENTS_CATALOG_OUTPUT_PATH=data/redhat-agents-catalog.yaml
 
 # Container parameters
 CONTAINER_RUNTIME?=$(shell command -v podman 2>/dev/null || command -v docker 2>/dev/null || echo docker)
@@ -35,7 +37,7 @@ DOCKER_IMAGE_NAME?=quay.io/opendatahub/odh-model-metadata-collection
 DOCKER_IMAGE_TAG?=latest
 DOCKER_FULL_IMAGE_NAME=$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
 
-.PHONY: all build build-report clean test test-coverage lint fmt vet deps check help run process process-models process-redhat-models process-validated-models process-other-models process-redhat-mcp process-partner-mcp process-community-mcp report run-with-report docker-build
+.PHONY: all build build-report clean test test-coverage lint fmt vet deps check help run process process-models process-redhat-models process-validated-models process-other-models process-redhat-mcp process-partner-mcp process-community-mcp process-agents report run-with-report docker-build
 
 # Default target
 all: check build
@@ -182,8 +184,16 @@ process-community-mcp: build
 	  	--mcp-catalog-output $(COMMUNITY_MCP_SERVERS_CATALOG_OUTPUT_PATH) \
 	  	--skip-huggingface --skip-enrichment --skip-catalog
 
-# Process all model indexes and MCP server catalogs
-process: process-models process-redhat-mcp process-partner-mcp process-community-mcp
+# Process Red Hat agents catalog (fetches metadata from GitHub)
+process-agents: build
+	@echo "Processing Red Hat agents catalog..."
+	./$(BUILD_DIR)/$(BINARY_NAME) \
+	  	--agent-index $(REDHAT_AGENTS_INDEX_PATH) \
+	  	--agent-catalog-output $(REDHAT_AGENTS_CATALOG_OUTPUT_PATH) \
+	  	--skip-huggingface --skip-enrichment --skip-catalog
+
+# Process all model indexes, MCP server catalogs, and agent catalogs
+process: process-models process-redhat-mcp process-partner-mcp process-community-mcp process-agents
 
 # Generate metadata completeness report
 report: build-report

--- a/cmd/model-extractor/main.go
+++ b/cmd/model-extractor/main.go
@@ -48,6 +48,10 @@ var (
 	mcpIndexPath             = flag.String("mcp-index", "", "Path to MCP servers index YAML file (if set, generates MCP catalog)")
 	mcpCatalogOutputPath     = flag.String("mcp-catalog-output", "data/redhat-mcp-servers-catalog.yaml", "Path for the generated MCP servers catalog")
 	skipMCPEnrichment        = flag.Bool("skip-mcp-enrichment", false, "Skip MCP server OCI image enrichment (architectures, timestamps)")
+	agentIndexPath           = flag.String("agent-index", "", "Path to agents index YAML file (if set, generates agents catalog)")
+	agentCatalogOutputPath   = flag.String("agent-catalog-output", "data/redhat-agents-catalog.yaml", "Path for the generated agents catalog")
+	agentBranch              = flag.String("agent-branch", "", "Override the GitHub branch for agent metadata fetching (defaults to branch in index file)")
+	skipAgentEnrichment      = flag.Bool("skip-agent-enrichment", false, "Skip fetching agent metadata and READMEs from GitHub")
 	help                     = flag.Bool("help", false, "Show help message")
 )
 
@@ -257,6 +261,14 @@ func main() {
 		}
 	}
 
+	// Process agents catalog (if index path is provided).
+	if *agentIndexPath != "" {
+		log.Printf("Processing agents catalog from: %s", *agentIndexPath)
+		if err := catalog.CreateAgentsCatalog(*agentIndexPath, *agentCatalogOutputPath, *agentBranch, *skipAgentEnrichment); err != nil {
+			log.Fatalf("Failed to create agents catalog: %v", err)
+		}
+	}
+
 	log.Println("Model metadata collection completed successfully!")
 }
 
@@ -295,6 +307,12 @@ func printHelp() {
 	fmt.Println("")
 	fmt.Println("  # Generate MCP servers catalog without OCI enrichment (offline)")
 	fmt.Printf("  %s --mcp-index data/redhat-mcp-servers-index.yaml --skip-huggingface --skip-enrichment --skip-catalog --skip-mcp-enrichment\n", os.Args[0])
+	fmt.Println("")
+	fmt.Println("  # Generate agents catalog (fetches metadata from GitHub)")
+	fmt.Printf("  %s --agent-index data/redhat-agents-index.yaml --skip-huggingface --skip-enrichment --skip-catalog\n", os.Args[0])
+	fmt.Println("")
+	fmt.Println("  # Generate agents catalog without GitHub fetching (offline)")
+	fmt.Printf("  %s --agent-index data/redhat-agents-index.yaml --skip-huggingface --skip-enrichment --skip-catalog --skip-agent-enrichment\n", os.Args[0])
 }
 
 // getStaticCatalogPaths returns the list of static catalog files to process

--- a/cmd/model-extractor/main.go
+++ b/cmd/model-extractor/main.go
@@ -126,6 +126,10 @@ func main() {
 	log.Printf("  MCP Index: %s", *mcpIndexPath)
 	log.Printf("  MCP Catalog Output: %s", *mcpCatalogOutputPath)
 	log.Printf("  Skip MCP Enrichment: %v", *skipMCPEnrichment)
+	log.Printf("  Agent Index: %s", *agentIndexPath)
+	log.Printf("  Agent Catalog Output: %s", *agentCatalogOutputPath)
+	log.Printf("  Agent Branch Override: %s", *agentBranch)
+	log.Printf("  Skip Agent Enrichment: %v", *skipAgentEnrichment)
 
 	// Determine if model processing should run.
 	// Skip when all model pipeline steps are disabled, regardless of MCP processing.

--- a/data/redhat-agents-catalog.yaml
+++ b/data/redhat-agents-catalog.yaml
@@ -283,7 +283,6 @@ agents:
         - [Ollama Documentation](https://ollama.com/docs)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/langgraph/templates/react_agent
       framework: langgraph
-      agentType: starter_kit
       env:
         - name: API_KEY
           required: true
@@ -707,7 +706,6 @@ agents:
         - [Milvus Documentation](https://milvus.io/docs)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/langgraph/templates/agentic_rag
       framework: langgraph
-      agentType: starter_kit
       env:
         - name: API_KEY
           required: true
@@ -1198,7 +1196,6 @@ agents:
         - [PostgreSQL Documentation](https://www.postgresql.org/docs/)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/langgraph/templates/react_with_database_memory
       framework: langgraph
-      agentType: starter_kit
       env:
         - name: API_KEY
           required: true
@@ -1718,7 +1715,6 @@ agents:
         - [Ollama Documentation](https://ollama.com/docs)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/langgraph/templates/human_in_the_loop
       framework: langgraph
-      agentType: starter_kit
       env:
         - name: API_KEY
           required: true
@@ -2072,7 +2068,6 @@ agents:
         - [CrewAI Tools](https://docs.crewai.com/concepts/tools)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/crewai/templates/websearch_agent
       framework: crewai
-      agentType: starter_kit
       env:
         - name: API_KEY
           required: true
@@ -2402,7 +2397,6 @@ agents:
         - [Ollama Documentation](https://ollama.com/docs)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/llamaindex/templates/websearch_agent
       framework: llamaindex
-      agentType: starter_kit
       env:
         - name: API_KEY
           required: true
@@ -2693,7 +2687,6 @@ agents:
         - [OpenAI Responses API](https://developers.openai.com/api/reference/resources/responses/methods/create)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/vanilla_python/templates/openai_responses_agent
       framework: vanilla_python
-      agentType: starter_kit
       env:
         - name: API_KEY
           required: true
@@ -3164,7 +3157,6 @@ agents:
         - MCP server in this repo: `mcp_automl_template/` (README, tool configuration, deploy)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/autogen/templates/mcp_agent
       framework: autogen
-      agentType: starter_kit
       env:
         - name: API_KEY
           required: true
@@ -3543,7 +3535,6 @@ agents:
         MIT License
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/google/templates/adk
       framework: google-adk
-      agentType: starter_kit
       env:
         - name: API_KEY
           required: true
@@ -3852,7 +3843,10 @@ agents:
         - [National Park Service API](https://developer.nps.gov) — Park search and alerts (free key required)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/langflow/templates/simple_tool_calling_agent
       framework: langflow
-      agentType: starter_kit
+      customProperties:
+        deploymentModel:
+            metadataType: MetadataStringValue
+            string_value: "flow-import"
     - name: a2a-langgraph-crewai
       displayName: A2A LangGraph ↔ CrewAI
       description: A2A demo — CrewAI specialist and LangGraph orchestrator (one Dockerfile; two tags / image refs for deploy).
@@ -4282,7 +4276,6 @@ agents:
         - Related patterns: `agents/google/templates/adk/` (Helm + `make build` / `make push` / `make deploy`), `agents/llamaindex/templates/websearch_agent/`, `agents/langgraph/templates/react_agent/`
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/a2a/templates/langgraph_crewai_agent
       framework: a2a
-      agentType: starter_kit
       env:
         - name: API_KEY
           required: true
@@ -5354,7 +5347,6 @@ agents:
         Use `LLMInferenceService` when you need the llm-d router/scheduler for multi-replica intelligent routing. Use standalone Deployment for single-replica setups or when the init container stalls.
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/claude-code
       framework: claude-code
-      agentType: starter_kit
     - name: openclaw
       displayName: OpenClaw on OpenShift
       description: Deploy OpenClaw on OpenShift with vLLM model serving, OAuth SSO, and production-grade security.
@@ -5491,7 +5483,6 @@ agents:
         - Tested on OpenShell v0.0.58, OpenShift 4.21 (June 2026).
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/openclaw/deployment
       framework: openclaw
-      agentType: starter_kit
     - name: codex
       displayName: Codex on OpenShift
       description: Run OpenAI Codex CLI inside an OpenShell sandbox on OpenShift.
@@ -5527,7 +5518,6 @@ agents:
         - Tested on OpenShell v0.0.58, OpenShift 4.21 (June 2026). Codex CLI version 0.139.0.
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/codex/deployment
       framework: codex
-      agentType: starter_kit
     - name: opencode
       displayName: OpenCode on OpenShift
       description: Run OpenCode inside an OpenShell sandbox on OpenShift.
@@ -5567,4 +5557,3 @@ agents:
         - Tested on OpenShell v0.0.58, OpenShift 4.21 (June 2026). OpenCode version 1.17.1.
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/opencode/deployment
       framework: opencode
-      agentType: starter_kit

--- a/data/redhat-agents-catalog.yaml
+++ b/data/redhat-agents-catalog.yaml
@@ -1,0 +1,5570 @@
+source: Red Hat Agents
+agents:
+    - name: langgraph-react-agent
+      displayName: LangGraph ReAct Agent
+      description: General-purpose ReAct agent built with LangGraph using a reason-and-act loop with external tools.
+      readme: |
+        <div style="text-align: center;">
+
+        ![LangGraph Logo](/images/langgraph_logo.svg)
+
+        # ReACT Agent
+
+        </div>
+
+        ---
+
+        ## What this agent does
+
+        General-purpose agent using a ReAct loop: it reasons and calls tools (e.g. search, math) step by step. Built with
+        LangGraph and LangChain.
+
+        ---
+
+        ## Prerequisites
+
+        - [uv](https://docs.astral.sh/uv/) — Python package manager
+        - [Podman](https://podman.io/) or [Docker](https://www.docker.com/) — for local container builds (Option A)
+        - [oc](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) — for
+          OpenShift deployment
+        - [Helm](https://helm.sh/) — for deploying to Kubernetes/OpenShift
+        - [GNU Make](https://www.gnu.org/software/make/) and a bash-compatible shell — on Windows,
+          use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (recommended)
+          or [Git Bash](https://git-scm.com/downloads)
+
+        ## Local Development
+
+        ### Initiating base
+
+        `make init` creates a `.env` file from `.env.example`. Set your environment variables in the `.env` file.
+
+        ```bash
+        cd agents/langgraph/templates/react_agent
+        make init
+        ```
+
+        ### Creating environment
+
+        Now you will remove old .venv and create new. Next dependencies will be installed.
+
+        ```bash
+        make env
+        ```
+
+        ### Tracing (optional)
+
+        Tracing is optional. If MLflow tracing is required, enable it by uncommenting and setting the following environment variables in the `.env` file. For how tracing works under the hood (span structure, autolog behavior, verification steps), see [tracing.md](../../../../tracing.md).
+
+        #### Tracing with a local MLflow server
+
+        ```ini
+        MLFLOW_TRACKING_URI="http://localhost:5000"
+        MLFLOW_EXPERIMENT_NAME="langgraph-react-agent"
+        MLFLOW_HTTP_REQUEST_TIMEOUT=2
+        MLFLOW_HTTP_REQUEST_MAX_RETRIES=0
+        ```
+
+        Then start the MLflow server in a separate terminal:
+
+        ```bash
+        # Start the MLflow server
+        cd agents/langgraph/templates/react_agent
+        uv run --extra tracing mlflow server --port 5000
+        ```
+
+        When `MLFLOW_TRACKING_URI` is set, `make run-app` and `make run-cli` will automatically install the tracing dependency.
+
+        #### Tracing with MLflow on OpenShift (RHOAI)
+
+        See `.env.example` for the supported configurations (local dev with manual token, in-pod with K8s service account auth). For TLS, authentication, and RBAC setup, see [MLflow on OpenShift: Authentication and TLS](../../../../docs/mlflow-openshift-auth-and-tls.md).
+
+        **Notes:**
+
+        - Tracing is optional; if you do not set `MLFLOW_TRACKING_URI`, the application will run without MLflow logging.
+
+        - If `MLFLOW_TRACKING_URI` is set, the application will attempt to connect to the MLflow server at startup. If the server is unreachable, the application will log a warning and continue running without tracing.
+
+        - You can control how long the application waits for the MLflow server by setting `MLFLOW_HEALTH_CHECK_TIMEOUT` (in seconds, default: `5`).
+
+        ### Setup Ollama
+
+        This will install ollama if it is not installed already. Then pull needed models for local work.
+        The default model is `llama3.1:8b`. To use a different model, pass `MODEL=`:
+        `make ollama MODEL=llama3.2:3b`
+
+        ```bash
+        make ollama
+        ```
+
+        ### Run OGX server
+
+        > **Keep this terminal open** – the server needs to keep running.
+        > You should see output indicating the server started on `http://localhost:8321`.
+
+        ```bash
+        make ogx-server
+        ```
+
+        ### Run the interactive web application
+
+        > **Keep this terminal open** – the app needs to keep running.
+        > You should see output indicating the app started on `http://localhost:8000`.
+
+        ```bash
+        cd agents/langgraph/templates/react_agent
+        make run-app           # fails if port is already in use and print steps TO-DO
+        ```
+
+        ### Interactive CLI
+
+        For terminal-based testing without a browser:
+
+        ```bash
+        cd agents/langgraph/templates/react_agent
+        make run-cli
+        ```
+
+        This launches an interactive prompt where you can pick predefined questions or type your own. Tool calls and results are
+        displayed inline with colored output.
+
+        ## Deploying to OpenShift
+
+        ### Setup
+
+        ```bash
+        cd agents/langgraph/templates/react_agent
+        make init
+        ```
+
+        ### Configuration
+
+        Edit `.env` with your model endpoint and container image:
+
+        ```ini
+        API_KEY = your-api-key-here
+        BASE_URL = https://your-model-endpoint.com/v1
+        MODEL_ID = llama-3.1-8b-instruct
+        CONTAINER_IMAGE = quay.io/your-username/langgraph-react-agent:latest
+        ```
+
+        **Notes:**
+
+        - `API_KEY` - your API key or contact your cluster administrator
+        - `BASE_URL` - should end with `/v1`. For local OGX, use `http://localhost:8321/v1`
+        - `MODEL_ID` - model identifier available on your endpoint
+          - **Local OGX:** requires `ollama/` prefix (e.g., `ollama/Llama3.1:8B`)
+          - **Cluster deployment:** discover available models via `curl $BASE_URL/models` or check your model serving dashboard
+        - `CONTAINER_IMAGE` – full image path where the agent container will be pushed and pulled from. The image is built
+          locally, pushed to this registry, and then deployed to OpenShift.
+
+          Format: `<registry>/<namespace>/<image-name>:<tag>`
+
+          Examples:
+
+          - Quay.io: `quay.io/your-username/langgraph-react-agent:latest`
+          - Docker Hub: `docker.io/your-username/langgraph-react-agent:latest`
+          - GHCR: `ghcr.io/your-org/langgraph-react-agent:latest`
+
+          > **Note:** OpenShift must be able to pull the container image. Make the image **public**, or configure
+          an [image pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html)
+          for private registries.
+
+        ### Building the Container Image
+
+        Login to OC
+
+        ```bash
+        oc login -u "login" -p "password" https://super-link-to-cluster:111
+        ```
+
+        Login ex. Docker
+
+        ```bash
+        docker login -u='login' -p='password' quay.io
+        ```
+
+        #### Option A: Build locally and push to a registry
+
+        Requires Podman (or Docker) and a registry account (e.g., Quay.io).
+
+        ```bash
+        make build    # builds the image locally
+        make push     # pushes to the registry specified in CONTAINER_IMAGE
+        ```
+
+        #### Option B: Build in-cluster via OpenShift BuildConfig
+
+        No Podman, Docker, or registry account needed — just the `oc` CLI.
+
+        ```bash
+        make build-openshift
+        ```
+
+        After the build completes, set `CONTAINER_IMAGE` in your `.env` to the internal registry URL printed after the build.
+
+        ### Deploying
+
+        #### Preview manifests (`make dry-run`)
+
+        ```bash
+        make dry-run          # preview rendered Helm manifests (secrets redacted)
+        ```
+
+        #### Deploy (`make deploy`)
+
+        ```bash
+        make deploy
+        ```
+
+        #### Verify deployment
+
+        After deploying, the application may take about a minute to become available while the pod starts up.
+
+        The route URL is printed after `make deploy`. You can also retrieve it manually:
+
+        ```bash
+        oc get route langgraph-react-agent -o jsonpath='{.spec.host}'
+        ```
+
+        #### Remove deployment (`make undeploy`)
+
+        ```bash
+        make undeploy
+        ```
+
+        See [OpenShift Deployment](../../../docs/openshift-deployment.md) for more details.
+
+        ## Tests
+
+        ```bash
+        make test
+        ```
+
+        ## API Endpoints
+
+        ### POST /chat/completions
+
+        Non-streaming:
+
+        ```bash
+        curl -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "What is the best cluster hosting service?"}], "stream": false}'
+        ```
+
+        Streaming:
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "What is the best cluster hosting service?"}], "stream": true}'
+        ```
+
+        Pretty Printed Stream:
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "What is the best cluster hosting service?"}], "stream": true}' |
+           jq -R -r -j --stream 'scan("^data:(.*)")[] | fromjson.choices[0].delta.content // empty'
+        ```
+
+        ### GET /health
+
+        ```bash
+        curl http://localhost:8000/health
+        ```
+
+        ## Resources
+
+        - [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)
+        - [LangChain Documentation](https://python.langchain.com/)
+        - [OGX Documentation](https://ogx-ai.github.io/docs/)
+        - [Ollama Documentation](https://ollama.com/docs)
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/langgraph/templates/react_agent
+      framework: langgraph
+      agentType: starter_kit
+      env:
+        - name: API_KEY
+          required: true
+        - name: BASE_URL
+          required: true
+        - name: MODEL_ID
+          required: true
+        - name: PORT
+          required: false
+        - name: CONTAINER_IMAGE
+          required: false
+        - name: AUTH_ENABLED
+          required: false
+        - name: AUTH_AUDIENCE
+          required: false
+        - name: AUTH_ALLOWED_SERVICEACCOUNTS
+          required: false
+    - name: langgraph-agentic-rag
+      displayName: LangGraph Agentic RAG Agent
+      description: RAG agent that indexes documents in a vector store (Milvus) and retrieves relevant chunks to augment the LLM's answers.
+      readme: |
+        <div style="text-align: center;">
+
+        ![LangGraph Logo](/images/langgraph_logo.svg)
+
+        # RAG Agent
+
+        </div>
+
+        ---
+
+        ## What this agent does
+
+        RAG (Retrieval-Augmented Generation) agent that indexes documents in a vector store and retrieves relevant
+        chunks to augment the LLM's answers with your own data. Built with LangGraph, LangChain, and OGX.
+        Supports Milvus Lite (local) and pgvector (OpenShift) as vector store backends.
+
+        ---
+
+        ## Prerequisites
+
+        - [uv](https://docs.astral.sh/uv/) — Python package manager
+        - [Podman](https://podman.io/) or [Docker](https://www.docker.com/) — for local container builds (Option A)
+        - [oc](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) — for
+          OpenShift deployment
+        - [Helm](https://helm.sh/) — for deploying to Kubernetes/OpenShift
+        - [GNU Make](https://www.gnu.org/software/make/) and a bash-compatible shell — on Windows,
+          use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (recommended)
+          or [Git Bash](https://git-scm.com/downloads)
+
+        ## Local Development
+
+        ### Initiating base
+
+        `make init` creates a `.env` file from `.env.example`. Set your environment variables in the `.env` file.
+
+        ```bash
+        cd agents/langgraph/templates/agentic_rag
+        make init
+        ```
+
+        ### Creating environment
+
+        Now you will remove old .venv and create new. Next dependencies will be installed.
+
+        ```bash
+        make env
+        ```
+
+        ### Tracing (optional)
+
+        Tracing is optional. If MLflow tracing is required, enable it by uncommenting and setting the following environment variables in the `.env` file.
+
+        #### Tracing with a local MLflow server
+
+        ```ini
+        MLFLOW_TRACKING_URI="http://localhost:5000"
+        MLFLOW_EXPERIMENT_NAME="langgraph-agentic-rag"
+        MLFLOW_HTTP_REQUEST_TIMEOUT=2
+        MLFLOW_HTTP_REQUEST_MAX_RETRIES=0
+        ```
+
+        Then start the MLflow server in a separate terminal:
+
+        ```bash
+        # Start the MLflow server
+        uv run --extra tracing mlflow server --port 5000
+        ```
+
+        When `MLFLOW_TRACKING_URI` is set, `make run-app` and `make run-cli` will automatically install the tracing dependency.
+
+        #### Tracing with an OpenShift MLflow server
+
+        To enable tracing and logging with MLflow on your OpenShift cluster, add the following environment variables to your `.env` file:
+
+        ```ini
+        MLFLOW_TRACKING_URI="https://<openshift-dashboard-url>/mlflow"
+        MLFLOW_TRACKING_TOKEN="<your-openshift-token>"
+        MLFLOW_EXPERIMENT_NAME="langgraph-agentic-rag"
+        MLFLOW_TRACKING_INSECURE_TLS="true"
+        MLFLOW_WORKSPACE="default"
+        ```
+
+        **Notes:**
+
+        - `MLFLOW_TRACKING_URI` - URL of your MLflow server. For local development, use `http://localhost:5000`. If using MLflow on an OpenShift cluster, replace `<openshift-dashboard-url>` with your cluster's data science gateway URL.
+        - `MLFLOW_TRACKING_TOKEN` - Required for OpenShift only. Your OpenShift authentication token, obtained from the OpenShift console.
+        - `MLFLOW_EXPERIMENT_NAME` - A descriptive name for your experiment (e.g., "LangGraph Agentic RAG Demo")
+        - `MLFLOW_TRACKING_INSECURE_TLS` - Required for OpenShift only. Set to `"true"` if your cluster does not use trusted certificates.
+        - `MLFLOW_WORKSPACE` - Required for OpenShift only. Project name.
+
+        - Tracing is optional; if you do not set `MLFLOW_TRACKING_URI`, the application will run without MLflow logging.
+
+        - If `MLFLOW_TRACKING_URI` is set, the application will attempt to connect to the MLflow server at startup. If the server is unreachable, the application will log a warning and continue running without tracing.
+
+        - You can control how long the application waits for the MLflow server by setting `MLFLOW_HEALTH_CHECK_TIMEOUT` (in seconds, default: `5`).
+
+        ### RAG Configuration
+
+        In addition to the model configuration, this agent requires RAG-specific settings in your `.env` file:
+
+        ```ini
+        EMBEDDING_MODEL=ollama/embeddinggemma:latest
+        EMBEDDING_DIMENSION=768
+        VECTOR_STORE_ID=
+        VECTOR_STORE_PROVIDER=milvus
+        VECTOR_STORE_PATH=/absolute/path/to/milvus_data/milvus_lite.db
+        DOCS_TO_LOAD=./data/sample_knowledge.txt
+        ```
+
+        **Notes:**
+
+        - `EMBEDDING_MODEL` - Model used for generating document embeddings. For local use with Ollama, pull the model first: `ollama pull embeddinggemma:latest`
+        - `EMBEDDING_DIMENSION` - Dimension of the embedding vectors (default: `768`). Must match the embedding model's output dimension.
+        - `VECTOR_STORE_ID` - Identifier for the vector store collection. If left empty, a new collection will be created when loading documents.
+        - `VECTOR_STORE_PROVIDER` - Vector store backend: `milvus` for local development (default), `pgvector` for OpenShift deployments.
+        - `VECTOR_STORE_PATH` - Absolute path where the Milvus Lite database will be stored. Not used when `VECTOR_STORE_PROVIDER=pgvector`.
+        - `DOCS_TO_LOAD` - Path to the text file containing documents to load into the vector store. A sample file is provided at `./data/sample_knowledge.txt`.
+
+        ### Setup Ollama
+
+        This will install ollama if it is not installed already. Then pull needed models for local work.
+        The default model is `llama3.1:8b`. To use a different model, pass `MODEL=`:
+        `make ollama MODEL=llama3.2:3b`
+
+        This also pulls the embedding model (`embeddinggemma:latest`) required for RAG.
+
+        ```bash
+        make ollama
+        ```
+
+        ### Run OGX server
+
+        > **Keep this terminal open** – the server needs to keep running.
+        > You should see output indicating the server started on `http://localhost:8321`.
+
+        ```bash
+        make ogx-server
+        ```
+
+        ### Load documents into vector store
+
+        Before running the agent, you need to load documents into the vector store.
+
+        If you do not have a `VECTOR_STORE_ID`, you can create one by running the document loader:
+
+        ```bash
+        make load-docs
+        ```
+
+        This will:
+
+        - Read documents from the file specified in `DOCS_TO_LOAD`
+        - Split documents into chunks (512 characters with 128 overlap by default)
+        - Generate embeddings using the model specified in `EMBEDDING_MODEL`
+        - Create a new vector store (using `VECTOR_STORE_PROVIDER`, defaults to `milvus` for local)
+        - Store chunks in the vector store
+        - Automatically write the new `VECTOR_STORE_ID` back to your `.env` file
+
+        ### Run the interactive web application
+
+        > **Keep this terminal open** – the app needs to keep running.
+        > You should see output indicating the app started on `http://localhost:8000`.
+
+        ```bash
+        cd agents/langgraph/templates/agentic_rag
+        make run-app           # fails if port is already in use and print steps TO-DO
+        ```
+
+        ### Interactive CLI
+
+        For terminal-based testing without a browser:
+
+        ```bash
+        cd agents/langgraph/templates/agentic_rag
+        make run-cli
+        ```
+
+        This launches an interactive prompt where you can pick predefined questions or type your own. Tool calls and results are
+        displayed inline with colored output.
+
+        ## Deploying to OpenShift
+
+        ### Setup
+
+        ```bash
+        cd agents/langgraph/templates/agentic_rag
+        make init
+        ```
+
+        ### Configuration
+
+        Edit `.env` with your model endpoint, RAG configuration, and container image.
+
+        #### Using an OGX server on the cluster
+
+        If an OGX server is already deployed on the cluster, use its external route URL so both LLM and vector store operations go through OGX:
+
+        ```ini
+        API_KEY=not-needed
+        BASE_URL=https://ogx-route-host/v1
+        MODEL_ID=vllm/qwen2-5-7b-instruct
+        CONTAINER_IMAGE=quay.io/your-username/langgraph-agentic-rag:latest
+
+        # RAG Configuration
+        EMBEDDING_MODEL=sentence-transformers/nomic-ai/nomic-embed-text-v1.5
+        EMBEDDING_DIMENSION=768
+        VECTOR_STORE_ID=
+        VECTOR_STORE_PROVIDER=pgvector
+        DOCS_TO_LOAD=./data/sample_knowledge.txt
+        ```
+
+        To discover the OGX route URL and available models on your cluster:
+
+        ```bash
+        # Pick the OGX route you want to use
+        oc get route -A | rg ogx
+
+        # Check available models
+        curl -s https://<route-host>/v1/models | python3 -m json.tool
+        ```
+
+        **Notes:**
+
+        - `API_KEY` - your API key or contact your cluster administrator. Use `not-needed` for OGX servers that don't require auth.
+        - `BASE_URL` - should end with `/v1`. For local OGX, use `http://localhost:8321/v1`. For OGX on the cluster, use the external route URL.
+        - `MODEL_ID` - model identifier available on your endpoint
+          - **Local OGX:** requires `ollama/` prefix (e.g., `ollama/Llama3.1:8B`)
+          - **Cluster deployment:** discover available models via `curl $BASE_URL/models` (see example above) and use the exact value OGX returns, such as `vllm/qwen2-5-7b-instruct`
+        - `VECTOR_STORE_PROVIDER` - vector store backend configured in your OGX server. Use `pgvector` or `milvus` depending on your OGX deployment.
+        - `CONTAINER_IMAGE` -- full image path where the agent container will be pushed and pulled from. The image is built
+          locally, pushed to this registry, and then deployed to OpenShift.
+
+          Format: `<registry>/<namespace>/<image-name>:<tag>`
+
+          Examples:
+
+          - Quay.io: `quay.io/your-username/langgraph-agentic-rag:latest`
+          - Docker Hub: `docker.io/your-username/langgraph-agentic-rag:latest`
+          - GHCR: `ghcr.io/your-org/langgraph-agentic-rag:latest`
+
+          > **Note:** OpenShift must be able to pull the container image. Make the image **public**, or configure
+          an [image pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html)
+          for private registries.
+
+        ### Loading Documents into the Vector Store (OpenShift)
+
+        Before deploying the agent, load documents into the OGX vector store. Run the loader script
+        locally, pointing it at the OGX server's external route (the same `BASE_URL` used in your `.env`):
+
+        ```bash
+        uv run python data/load_documents.py
+        ```
+
+        The script creates a new vector store, prints its ID, and writes the `VECTOR_STORE_ID` back to your `.env` file automatically.
+
+        ### Building the Container Image
+
+        Login to OC
+
+        ```bash
+        oc login -u "login" -p "password" https://super-link-to-cluster:111
+        ```
+
+        Login ex. Docker
+
+        ```bash
+        docker login -u='login' -p='password' quay.io
+        ```
+
+        #### Option A: Build locally and push to a registry
+
+        Requires Podman (or Docker) and a registry account (e.g., Quay.io).
+
+        ```bash
+        make build    # builds the image locally
+        make push     # pushes to the registry specified in CONTAINER_IMAGE
+        ```
+
+        #### Option B: Build in-cluster via OpenShift BuildConfig
+
+        No Podman, Docker, or registry account needed -- just the `oc` CLI.
+
+        ```bash
+        make build-openshift
+        ```
+
+        After the build completes, set `CONTAINER_IMAGE` in your `.env` to the internal registry URL printed after the build.
+
+        ### Deploying
+
+        #### Preview manifests (`make dry-run`)
+
+        ```bash
+        make dry-run          # preview rendered Helm manifests (secrets redacted)
+        ```
+
+        #### Deploy (`make deploy`)
+
+        ```bash
+        make deploy
+        ```
+
+        #### Verify deployment
+
+        After deploying, the application may take about a minute to become available while the pod starts up.
+
+        The route URL is printed after `make deploy`. You can also retrieve it manually:
+
+        ```bash
+        oc get route langgraph-agentic-rag -o jsonpath='{.spec.host}'
+        ```
+
+        #### Remove deployment (`make undeploy`)
+
+        ```bash
+        make undeploy
+        ```
+
+        See [OpenShift Deployment](../../../docs/openshift-deployment.md) for more details.
+
+        ## Tests
+
+        ```bash
+        make test
+        ```
+
+        ## API Endpoints
+
+        ### POST /chat/completions
+
+        Non-streaming:
+
+        ```bash
+        curl -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "What is LangChain?"}], "stream": false}'
+        ```
+
+        Streaming:
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "What is LangChain?"}], "stream": true}'
+        ```
+
+        Pretty Printed Stream:
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "What is LangChain?"}], "stream": true}' |
+           jq -R -r -j --stream 'scan("^data:(.*)")[] | fromjson.choices[0].delta.content // empty'
+        ```
+
+        ### GET /health
+
+        ```bash
+        curl http://localhost:8000/health
+        ```
+
+        ## How It Works
+
+        This agent implements a Retrieval-Augmented Generation (RAG) pattern:
+
+        1. **Document Indexing**: Documents are loaded from a text file, split into chunks, and embedded using the configured embedding model. The embeddings are stored in a vector database via OGX (supports Milvus and pgvector backends, configurable via `VECTOR_STORE_PROVIDER`).
+
+        2. **Query Processing**: When the user asks a question, the agent searches the vector store through OGX for the most relevant document chunks.
+
+        3. **Augmented Generation**: The retrieved chunks are provided as context to the LLM, which generates an answer grounded in the relevant documents. This reduces hallucination and allows the model to answer questions about your specific data.
+
+        The agent uses LangGraph to orchestrate the retrieval and generation steps, LangChain for the LLM integration, and OGX for vector store operations.
+
+        ## Behavioral Tests
+
+        Behavioral tests validate tool usage, response quality, latency, and reliability against a deployed agent.
+
+        ```bash
+        # Set the deployed agent URL
+        export AGENTIC_RAG_AGENT_URL=https://<your-agent-route>
+
+        # Optional: enable MLflow trace enrichment for tool_calls extraction
+        export MLFLOW_TRACKING_URI=https://<mlflow-route>/mlflow
+        export MLFLOW_EXPERIMENT_NAME=<experiment>
+
+        # Run all behavioral tests
+        pytest agents/langgraph/templates/agentic_rag/tests/behavioral/ -v
+
+        # Run specific test categories
+        pytest agents/langgraph/templates/agentic_rag/tests/behavioral/ -v -m "agentic_rag and not slow"
+        ```
+
+        See `tests/behavioral/` at the repo root for the shared test harness and threshold configuration.
+
+        ## Resources
+
+        - [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)
+        - [LangChain Documentation](https://python.langchain.com/)
+        - [OGX Documentation](https://ogx-ai.github.io/docs/)
+        - [Milvus Documentation](https://milvus.io/docs)
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/langgraph/templates/agentic_rag
+      framework: langgraph
+      agentType: starter_kit
+      env:
+        - name: API_KEY
+          required: true
+        - name: BASE_URL
+          required: true
+        - name: MODEL_ID
+          required: true
+        - name: PORT
+          required: false
+        - name: CONTAINER_IMAGE
+          required: false
+        - name: EMBEDDING_MODEL
+          required: false
+        - name: EMBEDDING_DIMENSION
+          required: false
+        - name: VECTOR_STORE_ID
+          required: false
+        - name: VECTOR_STORE_PROVIDER
+          required: false
+        - name: VECTOR_STORE_PATH
+          required: false
+        - name: DOCS_TO_LOAD
+          required: false
+    - name: langgraph-db-memory-agent
+      displayName: LangGraph ReAct Agent with Database Memory
+      description: ReAct agent with PostgreSQL-based conversation memory for persistent, thread-based chat history.
+      readme: |
+        <div style="text-align: center;">
+
+        ![LangGraph Logo](/images/langgraph_logo.svg)
+
+        # ReACT Agent with Database Memory
+
+        </div>
+
+        ---
+
+        ## What this agent does
+
+        ReAct agent with PostgreSQL-based conversation memory. It reasons and calls tools step by step (like the base ReAct
+        agent), but stores all conversation history in a PostgreSQL database using thread IDs so conversations persist across
+        sessions. Built with LangGraph, LangChain, and `langgraph-checkpoint-postgres`.
+
+        Key features:
+
+        - **Thread-based persistence** -- each conversation is identified by a unique `thread_id`
+        - **FIFO message trimming** -- only the most recent messages (default: 5) are sent to the LLM, keeping context windows
+          manageable
+        - **Auto-managed schema** -- PostgreSQL tables are created automatically on first run via LangGraph's `PostgresSaver`
+          checkpointer
+
+        ---
+
+        ## Prerequisites
+
+        - [uv](https://docs.astral.sh/uv/) -- Python package manager
+        - [Podman](https://podman.io/) or [Docker](https://www.docker.com/) -- for local container builds (Option A)
+        - [oc](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) -- for
+          OpenShift deployment
+        - [Helm](https://helm.sh/) -- for deploying to Kubernetes/OpenShift
+        - [GNU Make](https://www.gnu.org/software/make/) and a bash-compatible shell -- on Windows,
+          use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (recommended)
+          or [Git Bash](https://git-scm.com/downloads)
+        - **PostgreSQL 14+** -- managed service or local instance (see setup below)
+
+        ## Local Development
+
+        ### Initiating base
+
+        `make init` creates a `.env` file from `.env.example`. Set your environment variables in the `.env` file.
+
+        ```bash
+        cd agents/langgraph/templates/react_with_database_memory
+        make init
+        ```
+
+        ### Creating environment
+
+        Now you will remove old .venv and create new. Next dependencies will be installed.
+
+        ```bash
+        make env
+        ```
+
+        ### Tracing (optional)
+
+        Tracing is optional. If MLflow tracing is required, enable it by uncommenting and setting the following environment variables in the `.env` file.
+
+        #### Tracing with a local MLflow server
+
+        ```ini
+        MLFLOW_TRACKING_URI="http://localhost:5000"
+        MLFLOW_EXPERIMENT_NAME="langgraph-db-memory-agent"
+        MLFLOW_HTTP_REQUEST_TIMEOUT=2
+        MLFLOW_HTTP_REQUEST_MAX_RETRIES=0
+        ```
+
+        Then start the MLflow server in a separate terminal:
+
+        ```bash
+        # Start the MLflow server
+        uv run --extra tracing mlflow server --port 5000
+        ```
+
+        When `MLFLOW_TRACKING_URI` is set, `make run-app` and `make run-cli` will automatically install the tracing dependency.
+
+        #### Tracing with an OpenShift MLflow server
+
+        To enable tracing and logging with MLflow on your OpenShift cluster, add the following environment variables to your `.env` file:
+
+        ```ini
+        MLFLOW_TRACKING_URI="https://<openshift-dashboard-url>/mlflow"
+        MLFLOW_TRACKING_TOKEN="<your-openshift-token>"
+        MLFLOW_EXPERIMENT_NAME="langgraph-db-memory-agent"
+        MLFLOW_TRACKING_INSECURE_TLS="true"
+        MLFLOW_WORKSPACE="default"
+        ```
+
+        **Notes:**
+
+        - `MLFLOW_TRACKING_URI` - URL of your MLflow server. For local development, use `http://localhost:5000`. If using MLflow on an OpenShift cluster, replace `<openshift-dashboard-url>` with your cluster's data science gateway URL.
+        - `MLFLOW_TRACKING_TOKEN` - Required for OpenShift only. Your OpenShift authentication token, obtained from the OpenShift console.
+        - `MLFLOW_EXPERIMENT_NAME` - A descriptive name for your experiment (e.g., "LangGraph DB Memory Demo")
+        - `MLFLOW_TRACKING_INSECURE_TLS` - Required for OpenShift only. Set to `"true"` if your cluster does not use trusted certificates.
+        - `MLFLOW_WORKSPACE` - Required for OpenShift only. Project name.
+
+        - Tracing is optional; if you do not set `MLFLOW_TRACKING_URI`, the application will run without MLflow logging.
+
+        - If `MLFLOW_TRACKING_URI` is set, the application will attempt to connect to the MLflow server at startup. If the server is unreachable, the application will log a warning and continue running without tracing.
+
+        - You can control how long the application waits for the MLflow server by setting `MLFLOW_HEALTH_CHECK_TIMEOUT` (in seconds, default: `5`).
+
+        ### PostgreSQL Configuration
+
+        This agent requires a PostgreSQL database for conversation persistence. Add the following to your `.env`:
+
+        ```ini
+        POSTGRES_HOST=localhost
+        POSTGRES_PORT=5432
+        POSTGRES_DB=agent_memory
+        POSTGRES_USER=postgres
+        POSTGRES_PASSWORD=your_password_here
+        ```
+
+        | Variable            | Description                            | Example         |
+        |---------------------|----------------------------------------|-----------------|
+        | `POSTGRES_HOST`     | Database hostname                      | `localhost`     |
+        | `POSTGRES_PORT`     | Database port                          | `5432`          |
+        | `POSTGRES_DB`       | Database name for conversation history | `agent_memory`  |
+        | `POSTGRES_USER`     | Database username                      | `postgres`      |
+        | `POSTGRES_PASSWORD` | Database password                      | (your password) |
+
+        **Setting up a local PostgreSQL instance:**
+
+        Option 1 -- Docker/Podman:
+
+        ```bash
+        docker run --name postgres-agent \
+          -e POSTGRES_PASSWORD=mypassword \
+          -e POSTGRES_DB=agent_memory \
+          -p 5432:5432 \
+          -d postgres:16
+        ```
+
+        Option 2 -- Local PostgreSQL (macOS):
+
+        ```bash
+        brew install postgresql@16
+        brew services start postgresql@16
+        createdb agent_memory
+        ```
+
+        The database tables are created automatically on first run -- no manual schema setup is needed.
+
+        ### Setup Ollama
+
+        This will install ollama if it is not installed already. Then pull needed models for local work.
+        The default model is `llama3.1:8b`. To use a different model, pass `MODEL=`:
+        `make ollama MODEL=llama3.2:3b`
+
+        ```bash
+        make ollama
+        ```
+
+        ### Run OGX server
+
+        > **Keep this terminal open** – the server needs to keep running.
+        > You should see output indicating the server started on `http://localhost:8321`.
+
+        ```bash
+        make ogx-server
+        ```
+
+        ### Run the interactive web application
+
+        > **Keep this terminal open** – the app needs to keep running.
+        > You should see output indicating the app started on `http://localhost:8000`.
+
+        ```bash
+        cd agents/langgraph/templates/react_with_database_memory
+        make run-app           # fails if port is already in use and print steps TO-DO
+        ```
+
+        ### Interactive CLI
+
+        For terminal-based testing without a browser:
+
+        ```bash
+        cd agents/langgraph/templates/react_with_database_memory
+        make run-cli
+        ```
+
+        This launches an interactive prompt where you can pick predefined questions or type your own. Tool calls and results are
+        displayed inline with colored output. Your `thread_id` is shown at startup so you can resume conversations later.
+
+        ## Deploying to OpenShift
+
+        ### Setup
+
+        ```bash
+        cd agents/langgraph/templates/react_with_database_memory
+        make init
+        ```
+
+        ### Configuration
+
+        Edit `.env` with your model endpoint, PostgreSQL credentials, and container image:
+
+        ```ini
+        API_KEY = your-api-key-here
+        BASE_URL = https://your-model-endpoint.com/v1
+        MODEL_ID = llama-3.1-8b-instruct
+        CONTAINER_IMAGE = quay.io/your-username/langgraph-db-memory-agent:latest
+
+        POSTGRES_HOST = your-postgres-host.com
+        POSTGRES_PORT = 5432
+        POSTGRES_DB = agent_memory
+        POSTGRES_USER = your_db_user
+        POSTGRES_PASSWORD = your_db_password
+        ```
+
+        **Notes:**
+
+        - `API_KEY` - your API key or contact your cluster administrator
+        - `BASE_URL` - should end with `/v1`. For local OGX, use `http://localhost:8321/v1`
+        - `MODEL_ID` - model identifier available on your endpoint
+          - **Local OGX:** requires `ollama/` prefix (e.g., `ollama/Llama3.1:8B`)
+          - **Cluster deployment:** discover available models via `curl $BASE_URL/models` or check your model serving dashboard
+        - `CONTAINER_IMAGE` -- full image path where the agent container will be pushed and pulled from. The image is built
+          locally, pushed to this registry, and then deployed to OpenShift.
+
+          Format: `<registry>/<namespace>/<image-name>:<tag>`
+
+          Examples:
+
+          - Quay.io: `quay.io/your-username/langgraph-db-memory-agent:latest`
+          - Docker Hub: `docker.io/your-username/langgraph-db-memory-agent:latest`
+          - GHCR: `ghcr.io/your-org/langgraph-db-memory-agent:latest`
+
+          > **Note:** OpenShift must be able to pull the container image. Make the image **public**, or configure
+          an [image pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html)
+          for private registries.
+
+        - `POSTGRES_HOST` - PostgreSQL database hostname (must be accessible from the cluster)
+        - `POSTGRES_PASSWORD` - stored as a Kubernetes secret (never in plain-text manifests)
+
+        ### Building the Container Image
+
+        Login to OC
+
+        ```bash
+        oc login -u "login" -p "password" https://super-link-to-cluster:111
+        ```
+
+        Login ex. Docker
+
+        ```bash
+        docker login -u='login' -p='password' quay.io
+        ```
+
+        #### Option A: Build locally and push to a registry
+
+        Requires Podman (or Docker) and a registry account (e.g., Quay.io).
+
+        ```bash
+        make build    # builds the image locally
+        make push     # pushes to the registry specified in CONTAINER_IMAGE
+        ```
+
+        #### Option B: Build in-cluster via OpenShift BuildConfig
+
+        No Podman, Docker, or registry account needed -- just the `oc` CLI.
+
+        ```bash
+        make build-openshift
+        ```
+
+        After the build completes, set `CONTAINER_IMAGE` in your `.env` to the internal registry URL printed after the build.
+
+        ### Deploying
+
+        #### Preview manifests (`make dry-run`)
+
+        ```bash
+        make dry-run          # preview rendered Helm manifests (secrets redacted)
+        ```
+
+        #### Deploy (`make deploy`)
+
+        ```bash
+        make deploy
+        ```
+
+        #### Verify deployment
+
+        After deploying, the application may take about a minute to become available while the pod starts up.
+
+        The route URL is printed after `make deploy`. You can also retrieve it manually:
+
+        ```bash
+        oc get route langgraph-db-memory-agent -o jsonpath='{.spec.host}'
+        ```
+
+        #### Remove deployment (`make undeploy`)
+
+        ```bash
+        make undeploy
+        ```
+
+        See [OpenShift Deployment](../../../docs/openshift-deployment.md) for more details.
+
+        ## Tests
+
+        ### Unit tests
+
+        ```bash
+        make test
+        ```
+
+        ### Behavioral tests
+
+        Behavioral tests validate tool selection, response quality, latency, and reliability against a live agent. They require MLflow tracing to extract tool_calls from trace spans.
+
+        ```bash
+        DB_MEMORY_AGENT_URL=https://<agent-route> \
+        MLFLOW_TRACKING_URI=<mlflow-uri> \
+        MLFLOW_EXPERIMENT_NAME=<experiment> \
+        MLFLOW_TRACKING_TOKEN=$(oc whoami -t) \
+        pytest tests/behavioral/ -v
+        ```
+
+        Skip slow pass@k tests with `-m "not slow"`.
+
+        ## API Endpoints
+
+        ### POST /chat/completions
+
+        Non-streaming:
+
+        ```bash
+        curl -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "I will tell you a story about blue eyed Johnny! He liked ice creams. End."}], "stream": false, "thread_id": "test-conversation-1"}'
+        ```
+
+        Continue the conversation with the same `thread_id`:
+
+        ```bash
+        curl -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "What did we talk about?"}], "stream": false, "thread_id": "test-conversation-1"}'
+        ```
+
+        Streaming:
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "What did we talk about?"}], "stream": true, "thread_id": "test-conversation-1"}'
+        ```
+
+        Pretty Printed Stream:
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "What is the best cluster hosting service?"}], "stream": true}' |
+           jq -R -r -j --stream 'scan("^data:(.*)")[] | fromjson.choices[0].delta.content // empty'
+        ```
+
+        **Note:** The `thread_id` field is optional. When omitted, the agent runs without persistence (no conversation history
+        is saved). When provided, messages are stored in PostgreSQL and retrieved on subsequent requests with the same
+        `thread_id`.
+
+        ### GET /health
+
+        ```bash
+        curl http://localhost:8000/health
+        ```
+
+        ## Architecture
+
+        This agent combines three key components:
+
+        1. **LangGraph ReACT Agent** -- reasoning and action loop with tool calling
+        2. **PostgresSaver Checkpointer** -- persistent conversation memory in PostgreSQL
+        3. **ChatOpenAI** -- OpenAI-compatible LLM client (connects to OGX or any OpenAI-compatible endpoint)
+
+        ```text
+        User Input --> LangGraph Agent --> ChatOpenAI --> LLM (Ollama/OpenAI)
+                           |                               |
+                    PostgreSQL <-- PostgresSaver <-- Messages & State
+        ```
+
+        **Message Flow:**
+
+        1. User sends message with optional `thread_id`
+        2. Agent loads conversation history from PostgreSQL (if thread exists)
+        3. FIFO trimmer keeps only the last 5 messages for the LLM context window
+        4. Agent processes with ReACT loop (reason, act, observe)
+        5. New messages saved to PostgreSQL
+        6. Response returned to user
+
+        **Customization:**
+
+        Edit `src/react_with_database_memory/agent.py`:
+
+        ```python
+        # Change context window size (default: 5 messages)
+        max_messages_in_context = 10  # Keep last 10 messages
+
+        # Change default system prompt
+        default_system_prompt = "You are a specialized assistant..."
+        ```
+
+        ### Inspecting Conversation History
+
+        To list all stored threads or view messages in a specific thread:
+
+        1. Edit `examples/query_existing_deployment.py`
+        2. To list all threads, leave `thread_id` empty:
+
+           ```python
+           thread_id = ""
+           ```
+
+           To view messages for a specific thread, set it:
+
+           ```python
+           thread_id = "123e4567-e89b-12d3-a456-426614174000"
+           ```
+
+        3. Run the script:
+
+           ```bash
+           uv run python examples/query_existing_deployment.py
+           ```
+
+        ### Deleting Thread History
+
+        To permanently delete a conversation thread (or all threads), use the provided script:
+
+        1. Edit `examples/clear_thread_history.py`
+        2. To delete a specific thread, set the `thread_id`:
+
+           ```python
+           thread_id = "123e4567-e89b-12d3-a456-426614174000"
+           ```
+
+           To delete **all** threads, leave it empty:
+
+           ```python
+           thread_id = ""
+           ```
+
+        3. Run the script:
+
+           ```bash
+           uv run python examples/clear_thread_history.py
+           ```
+
+        ## Resources
+
+        - [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)
+        - [LangGraph Checkpointers](https://langchain-ai.github.io/langgraph/concepts/persistence/)
+        - [LangChain Documentation](https://python.langchain.com/)
+        - [OGX Documentation](https://ogx-ai.github.io/docs/)
+        - [PostgreSQL Documentation](https://www.postgresql.org/docs/)
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/langgraph/templates/react_with_database_memory
+      framework: langgraph
+      agentType: starter_kit
+      env:
+        - name: API_KEY
+          required: true
+        - name: BASE_URL
+          required: true
+        - name: MODEL_ID
+          required: true
+        - name: POSTGRES_HOST
+          required: true
+        - name: POSTGRES_PORT
+          required: true
+        - name: POSTGRES_DB
+          required: true
+        - name: POSTGRES_USER
+          required: true
+        - name: POSTGRES_PASSWORD
+          required: true
+        - name: PORT
+          required: false
+        - name: CONTAINER_IMAGE
+          required: false
+    - name: langgraph-hitl-agent
+      displayName: LangGraph Human-in-the-Loop Agent
+      description: LangGraph agent with human approval workflow that pauses for review before executing sensitive tools.
+      readme: |
+        <div style="text-align: center;">
+
+        ![LangGraph Logo](/images/langgraph_logo.svg)
+
+        # Human-in-the-Loop Agent
+
+        </div>
+
+        ---
+
+        ## What this agent does
+
+        Agent with **Human-in-the-Loop (HITL) approval** that pauses execution before running sensitive tools (e.g.
+        `create_file`) and waits for human review. Simple questions are answered directly without triggering the approval loop.
+        Built with LangGraph and LangChain.
+
+        **How it works:**
+
+        ```text
+        User Input → LLM decides tool → Is it sensitive?
+                                            ├── No  → Execute tool automatically → Return result
+                                            └── Yes → PAUSE (interrupt) → Human approves/rejects
+                                                                            ├── Approved → Execute tool → Return result
+                                                                            └── Rejected → Return rejection message
+        ```
+
+        ---
+
+        ## Prerequisites
+
+        - [uv](https://docs.astral.sh/uv/) — Python package manager
+        - [Podman](https://podman.io/) or [Docker](https://www.docker.com/) — for local container builds (Option A)
+        - [oc](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) — for
+          OpenShift deployment
+        - [Helm](https://helm.sh/) — for deploying to Kubernetes/OpenShift
+        - [GNU Make](https://www.gnu.org/software/make/) and a bash-compatible shell — on Windows,
+          use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (recommended)
+          or [Git Bash](https://git-scm.com/downloads)
+
+        ## Local Development
+
+        ### Initiating base
+
+        `make init` creates a `.env` file from `.env.example`. Set your environment variables in the `.env` file.
+
+        ```bash
+        cd agents/langgraph/templates/human_in_the_loop
+        make init
+        ```
+
+        ### Creating environment
+
+        Now you will remove old .venv and create new. Next dependencies will be installed.
+
+        ```bash
+        make env
+        ```
+
+        ### Tracing (optional)
+
+        Tracing is optional. If MLflow tracing is required, enable it by uncommenting and setting the following environment variables in the `.env` file.
+
+        #### Tracing with a local MLflow server
+
+        ```ini
+        MLFLOW_TRACKING_URI="http://localhost:5000"
+        MLFLOW_EXPERIMENT_NAME="langgraph-hitl-agent"
+        MLFLOW_HTTP_REQUEST_TIMEOUT=2
+        MLFLOW_HTTP_REQUEST_MAX_RETRIES=0
+        ```
+
+        Then start the MLflow server in a separate terminal:
+
+        ```bash
+        # Start the MLflow server
+        uv run --extra tracing mlflow server --port 5000
+        ```
+
+        When `MLFLOW_TRACKING_URI` is set, `make run-app` and `make run-cli` will automatically install the tracing dependency.
+
+        #### Tracing with an OpenShift MLflow server
+
+        To enable tracing and logging with MLflow on your OpenShift cluster, add the following environment variables to your `.env` file:
+
+        ```ini
+        MLFLOW_TRACKING_URI="https://<openshift-dashboard-url>/mlflow"
+        MLFLOW_TRACKING_TOKEN="<your-openshift-token>"
+        MLFLOW_EXPERIMENT_NAME="langgraph-hitl-agent"
+        MLFLOW_TRACKING_INSECURE_TLS="true"
+        MLFLOW_WORKSPACE="default"
+        ```
+
+        **Notes:**
+
+        - `MLFLOW_TRACKING_URI` - URL of your MLflow server. For local development, use `http://localhost:5000`. If using MLflow on an OpenShift cluster, replace `<openshift-dashboard-url>` with your cluster's data science gateway URL.
+        - `MLFLOW_TRACKING_TOKEN` - Required for OpenShift only. Your OpenShift authentication token, obtained from the OpenShift console.
+        - `MLFLOW_EXPERIMENT_NAME` - A descriptive name for your experiment (e.g., "LangGraph HITL Demo")
+        - `MLFLOW_TRACKING_INSECURE_TLS` - Required for OpenShift only. Set to `"true"` if your cluster does not use trusted certificates.
+        - `MLFLOW_WORKSPACE` - Required for OpenShift only. Project name.
+
+        - Tracing is optional; if you do not set `MLFLOW_TRACKING_URI`, the application will run without MLflow logging.
+
+        - If `MLFLOW_TRACKING_URI` is set, the application will attempt to connect to the MLflow server at startup. If the server is unreachable, the application will log a warning and continue running without tracing.
+
+        - You can control how long the application waits for the MLflow server by setting `MLFLOW_HEALTH_CHECK_TIMEOUT` (in seconds, default: `5`).
+
+        ### Setup Ollama
+
+        This will install ollama if it is not installed already. Then pull needed models for local work.
+        The default model is `llama3.1:8b`. To use a different model, pass `MODEL=`:
+        `make ollama MODEL=llama3.2:3b`
+
+        ```bash
+        make ollama
+        ```
+
+        ### Run OGX server
+
+        > **Keep this terminal open** – the server needs to keep running.
+        > You should see output indicating the server started on `http://localhost:8321`.
+
+        ```bash
+        make ogx-server
+        ```
+
+        ### Run the interactive web application
+
+        > **Keep this terminal open** – the app needs to keep running.
+        > You should see output indicating the app started on `http://localhost:8000`.
+
+        ```bash
+        cd agents/langgraph/templates/human_in_the_loop
+        make run-app           # fails if port is already in use and print steps TO-DO
+        ```
+
+        Open [http://localhost:8000](http://localhost:8000) in your browser. A green dot in the header means the agent is
+        connected and ready.
+
+        When the agent pauses for approval, an **Approve / Reject** banner appears directly in the chat.
+
+        ### Interactive CLI
+
+        For terminal-based testing without a browser:
+
+        ```bash
+        cd agents/langgraph/templates/human_in_the_loop
+        make run-cli
+        ```
+
+        This launches an interactive prompt where you can pick predefined questions or type your own. Tool calls and results are
+        displayed inline with colored output.
+
+        ## Deploying to OpenShift
+
+        ### Setup
+
+        ```bash
+        cd agents/langgraph/templates/human_in_the_loop
+        make init
+        ```
+
+        ### Configuration
+
+        Edit `.env` with your model endpoint and container image:
+
+        ```ini
+        API_KEY = your-api-key-here
+        BASE_URL = https://your-model-endpoint.com/v1
+        MODEL_ID = llama-3.1-8b-instruct
+        CONTAINER_IMAGE = quay.io/your-username/langgraph-hitl-agent:latest
+        ```
+
+        **Notes:**
+
+        - `API_KEY` - your API key or contact your cluster administrator
+        - `BASE_URL` - should end with `/v1`. For local OGX, use `http://localhost:8321/v1`
+        - `MODEL_ID` - model identifier available on your endpoint
+          - **Local OGX:** requires `ollama/` prefix (e.g., `ollama/Llama3.1:8B`)
+          - **Cluster deployment:** discover available models via `curl $BASE_URL/models` or check your model serving dashboard
+        - `CONTAINER_IMAGE` – full image path where the agent container will be pushed and pulled from. The image is built
+          locally, pushed to this registry, and then deployed to OpenShift.
+
+          Format: `<registry>/<namespace>/<image-name>:<tag>`
+
+          Examples:
+
+          - Quay.io: `quay.io/your-username/langgraph-hitl-agent:latest`
+          - Docker Hub: `docker.io/your-username/langgraph-hitl-agent:latest`
+          - GHCR: `ghcr.io/your-org/langgraph-hitl-agent:latest`
+
+          > **Note:** OpenShift must be able to pull the container image. Make the image **public**, or configure
+          an [image pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html)
+          for private registries.
+
+        ### Building the Container Image
+
+        Login to OC
+
+        ```bash
+        oc login -u "login" -p "password" https://super-link-to-cluster:111
+        ```
+
+        Login ex. Docker
+
+        ```bash
+        docker login -u='login' -p='password' quay.io
+        ```
+
+        #### Option A: Build locally and push to a registry
+
+        Requires Podman (or Docker) and a registry account (e.g., Quay.io).
+
+        ```bash
+        make build    # builds the image locally
+        make push     # pushes to the registry specified in CONTAINER_IMAGE
+        ```
+
+        #### Option B: Build in-cluster via OpenShift BuildConfig
+
+        No Podman, Docker, or registry account needed — just the `oc` CLI.
+
+        ```bash
+        make build-openshift
+        ```
+
+        After the build completes, set `CONTAINER_IMAGE` in your `.env` to the internal registry URL printed after the build.
+
+        ### Deploying
+
+        #### Preview manifests (`make dry-run`)
+
+        ```bash
+        make dry-run          # preview rendered Helm manifests (secrets redacted)
+        ```
+
+        #### Deploy (`make deploy`)
+
+        ```bash
+        make deploy
+        ```
+
+        #### Verify deployment
+
+        After deploying, the application may take about a minute to become available while the pod starts up.
+
+        The route URL is printed after `make deploy`. You can also retrieve it manually:
+
+        ```bash
+        oc get route langgraph-hitl-agent -o jsonpath='{.spec.host}'
+        ```
+
+        #### Remove deployment (`make undeploy`)
+
+        ```bash
+        make undeploy
+        ```
+
+        See [OpenShift Deployment](../../../docs/openshift-deployment.md) for more details.
+
+        ### Testing on OpenShift
+
+        Replace `http://localhost:8000` with `https://<YOUR_ROUTE_URL>` in the examples below.
+
+        **Step 1: Ask a general question (no approval needed)**
+
+        ```bash
+        curl -X POST https://<YOUR_ROUTE_URL>/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{
+            "messages": [{"role": "user", "content": "What is RedHat OpenShift Cluster"}],
+            "stream": false,
+            "thread_id": "demo-1"
+          }'
+        ```
+
+        **Step 2: Ask to write that info into a file (triggers approval)**
+
+        ```bash
+        curl -X POST https://<YOUR_ROUTE_URL>/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{
+            "messages": [{"role": "user", "content": "Write that information into a file called demo.md"}],
+            "stream": false,
+            "thread_id": "demo-1"
+          }'
+        ```
+
+        The agent will pause and return `finish_reason: "pending_approval"` with the `create_file` tool call details.
+
+        **Step 3: Approve the file creation**
+
+        ```bash
+        curl -X POST https://<YOUR_ROUTE_URL>/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{
+            "messages": [{"role": "user", "content": ""}],
+            "thread_id": "demo-1",
+            "approval": "yes"
+          }'
+        ```
+
+        The agent resumes, executes `create_file`, and returns the final result.
+
+        ## Tests
+
+        ```bash
+        make test
+        ```
+
+        ### Behavioral Tests
+
+        Behavioral tests validate tool selection, response quality, latency, and reliability against a live agent instance.
+
+        ```bash
+        # From the repo root (not the agent directory)
+        HITL_AGENT_URL=https://<agent-route> \
+        MLFLOW_TRACKING_URI=<mlflow-uri> \
+        MLFLOW_EXPERIMENT_NAME=<experiment> \
+        uv run --extra test --extra test-mlflow python -m pytest agents/langgraph/templates/human_in_the_loop/tests/behavioral/ -v
+        ```
+
+        Thresholds are configured in `tests/behavioral/configs/thresholds.yaml` under the `langgraph_hitl` section.
+
+        ## API Endpoints
+
+        ### POST /chat/completions
+
+        Non-streaming:
+
+        ```bash
+        curl -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "What is RedHat OpenShift?"}], "stream": false, "thread_id": "demo-1"}'
+        ```
+
+        Streaming:
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "What is RedHat OpenShift?"}], "stream": true, "thread_id": "demo-1"}'
+        ```
+
+        ### GET /health
+
+        ```bash
+        curl http://localhost:8000/health
+        ```
+
+        ## Human-in-the-Loop Features
+
+        ### How Approval Works
+
+        This agent classifies tools into two categories:
+
+        | Category      | Tools         | Behavior                                  |
+        |---------------|---------------|-------------------------------------------|
+        | **Safe**      | general chat  | Responded to directly, no approval needed |
+        | **Sensitive** | `create_file` | Paused for human review before execution  |
+
+        When the LLM decides to call a sensitive tool, the agent:
+
+        1. **Pauses** execution using LangGraph's `interrupt()` mechanism
+        2. **Returns** the pending tool call details with `finish_reason: "pending_approval"`
+        3. **Includes** a `thread_id` to identify the paused conversation
+        4. **Waits** for a follow-up request with the human's decision
+
+        ### API Approval Flow
+
+        **Step 1: Send a message that triggers a sensitive tool**
+
+        ```bash
+        curl -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{
+            "messages": [{"role": "user", "content": "Create a file named report.md with info about LangChain"}],
+            "stream": false,
+            "thread_id": "conversation-1"
+          }'
+        ```
+
+        **Response** (agent paused, waiting for approval):
+
+        ```json
+        {
+          "choices": [
+            {
+              "message": {
+                "role": "assistant",
+                "content": "{\"question\": \"Do you approve the following tool call(s)?\", \"tool_calls\": [\"Tool: create_file, Args: {...}\"], \"options\": [\"yes\", \"no\"]}"
+              },
+              "finish_reason": "pending_approval"
+            }
+          ],
+          "thread_id": "conversation-1"
+        }
+        ```
+
+        **Step 2: Approve or reject the tool call**
+
+        ```bash
+        # Approve
+        curl -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{
+            "messages": [{"role": "user", "content": ""}],
+            "thread_id": "conversation-1",
+            "approval": "yes"
+          }'
+
+        # Or reject
+        curl -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{
+            "messages": [{"role": "user", "content": ""}],
+            "thread_id": "conversation-1",
+            "approval": "no"
+          }'
+        ```
+
+        ### Thread-Based Conversations
+
+        Each conversation requires a `thread_id` for HITL to work:
+
+        - The `thread_id` identifies the paused graph state
+        - You **must** use the same `thread_id` when sending the approval
+        - State is stored in-memory using LangGraph's `MemorySaver` checkpointer
+        - State does not persist across server restarts (use a database checkpointer for production)
+
+        ### Customization
+
+        Edit `src/human_in_the_loop/agent.py` to add more sensitive tools to the interrupt list:
+
+        ```python
+        hitl_middleware = HumanInTheLoopMiddleware(
+            interrupt_on={
+                "create_file": True,
+                "delete_record": True,
+            },
+        )
+        ```
+
+        Edit `src/human_in_the_loop/tools.py` to add new tools:
+
+        ```python
+        @tool("delete_record", parse_docstring=True)
+        def delete_record(record_id: str) -> str:
+            """Delete a record from the database. Requires human approval."""
+            # Implementation here
+        ```
+
+        ### Architecture
+
+        This agent combines three key components:
+
+        1. **LangGraph StateGraph**: Custom workflow with conditional routing for safe vs sensitive tools
+        2. **LangGraph Interrupts**: `interrupt()` pauses execution; `Command(resume=...)` resumes it
+        3. **ChatOpenAI**: OpenAI-compatible LLM client (connects to OGX or OpenAI)
+
+        ```text
+        User Input → Agent Node (LLM) → Route Decision
+                                           ├── No tools → END
+                                           ├── Safe tool → Tool Node → Agent Node (loop)
+                                           └── Sensitive tool → Human Approval Node
+                                                                  ├── interrupt() → PAUSE
+                                                                  ├── resume("yes") → Tool Node → Agent Node → END
+                                                                  └── resume("no") → Rejection Message → END
+        ```
+
+        ### Troubleshooting
+
+        **Error: "No user message found in messages list"**
+
+        - Solution: Ensure your request includes at least one message with `"role": "user"`
+
+        **Approval request returns error**
+
+        - Solution: Use the same `thread_id` from the pending approval response
+        - The graph state must exist in the checkpointer for resume to work
+
+        **State lost after server restart**
+
+        - The default `MemorySaver` is in-memory only
+        - For production, use `PostgresSaver` (see `react_with_database_memory` agent for reference)
+
+        ## Resources
+
+        - [LangGraph Interrupts](https://langchain-ai.github.io/langgraph/concepts/human_in_the_loop/)
+        - [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)
+        - [LangChain Documentation](https://python.langchain.com/)
+        - [OGX Documentation](https://ogx-ai.github.io/docs/)
+        - [Ollama Documentation](https://ollama.com/docs)
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/langgraph/templates/human_in_the_loop
+      framework: langgraph
+      agentType: starter_kit
+      env:
+        - name: API_KEY
+          required: true
+        - name: BASE_URL
+          required: true
+        - name: MODEL_ID
+          required: true
+        - name: PORT
+          required: false
+        - name: CONTAINER_IMAGE
+          required: false
+    - name: crewai-websearch-agent
+      displayName: CrewAI WebSearch Agent
+      description: Web search agent built with CrewAI using a ReAct-style crew with a web search tool to answer user questions.
+      readme: |
+        <div style="text-align: center;">
+
+        ![CrewAI Logo](/images/crewai_logo.svg)
+
+        # WebSearch Agent
+
+        </div>
+
+        ---
+
+        ## What this agent does
+
+        Web search agent built with the CrewAI framework. Uses a ReAct-style crew with a web search tool to answer user
+        questions. Use with any OpenAI-compatible API.
+
+        **Note:** CrewAI agents typically need a larger model (e.g. `llama3.1:8b`) than the other agents in this repo.
+
+        ---
+
+        ## Prerequisites
+
+        - [uv](https://docs.astral.sh/uv/) — Python package manager
+        - [Podman](https://podman.io/) or [Docker](https://www.docker.com/) — for local container builds (Option A)
+        - [oc](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) — for
+          OpenShift deployment
+        - [Helm](https://helm.sh/) — for deploying to Kubernetes/OpenShift
+        - [GNU Make](https://www.gnu.org/software/make/) and a bash-compatible shell — on Windows,
+          use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (recommended)
+          or [Git Bash](https://git-scm.com/downloads)
+
+        ## Local Development
+
+        ### Initiating base
+
+        Here you copy .env.example file into .env
+
+        ```bash
+        cd agents/crewai/templates/websearch_agent
+        make init
+        ```
+
+        Edit `.env` with your configuration, then:
+
+        See [Local Development](../../../docs/local-development.md) for Ollama + OGX setup for local model serving.
+
+        ### Pointing to a remotely hosted model
+
+        ```ini
+        API_KEY=your-api-key-here
+        BASE_URL=https://your-model-endpoint.com/v1
+        MODEL_ID=llama-3.1-8b-instruct
+        ```
+
+        **Notes:**
+
+        - `API_KEY` — your API key or contact your cluster administrator
+        - `BASE_URL` — should end with `/v1`. For local OGX, use `http://localhost:8321/v1`
+        - `MODEL_ID` — model identifier available on your endpoint. For local OGX, requires `ollama/` prefix (e.g., `ollama/Llama3.1:8B`)
+
+        ### Creating environment
+
+        Now you will remove old .venv and create new. Next dependencies will be installed.
+
+        ```bash
+        make env
+        ```
+
+        ### Setup Ollama
+
+        This will install ollama if it is not installed already. Then pull needed models for local work.
+        The default model is `llama3.1:8b`. To use a different model, pass `MODEL=`:
+        `make ollama MODEL=llama3.2:3b`
+
+        ```bash
+        make ollama
+        ```
+
+        ### Run OGX server
+
+        > **Keep this terminal open** – the server needs to keep running.
+        > You should see output indicating the server started on `http://localhost:8321`.
+
+        ```bash
+        make ogx-server
+        ```
+
+        ### Run the interactive web application
+
+        > **Keep this terminal open** – the app needs to keep running.
+        > You should see output indicating the app started on `http://localhost:8000`.
+
+        ```bash
+        cd agents/crewai/templates/websearch_agent
+        make run-app           # fails if port is already in use and print steps TO-DO
+        ```
+
+        ### Interactive CLI
+
+        For terminal-based testing without a browser:
+
+        ```bash
+        cd agents/crewai/templates/websearch_agent
+        make run-cli
+        ```
+
+        ### Tracing with a local MLflow server
+
+        To enable MLflow tracing, add the following to your `.env`:
+
+        ```ini
+        MLFLOW_TRACKING_URI = "http://localhost:5000"
+        MLFLOW_EXPERIMENT_NAME = "crewai-websearch-agent"
+        MLFLOW_HTTP_REQUEST_TIMEOUT = 2
+        MLFLOW_HTTP_REQUEST_MAX_RETRIES = 0
+        ```
+
+        Then start the MLflow server in a separate terminal:
+
+        ```bash
+        # Start the MLflow server
+        uv run --extra tracing mlflow server --port 5000
+        ```
+
+        When `MLFLOW_TRACKING_URI` is set, `make run-app` and `make run-cli` will automatically install the tracing dependency.
+
+        #### Configuring the LLM provider for tracing
+
+        CrewAI can use different LLM providers. Set `LLM_PROVIDER` to match your provider so MLflow uses the correct autolog
+        integration:
+
+        | `LLM_PROVIDER` value | MLflow autolog enabled       | When to use                 |
+        |----------------------|------------------------------|-----------------------------|
+        | `litellm` (default)  | `mlflow.litellm.autolog()`   | OpenAI-compatible endpoints |
+        | `openai`             | `mlflow.openai.autolog()`    | Direct OpenAI API           |
+        | `anthropic`          | `mlflow.anthropic.autolog()` | Anthropic API               |
+        | `gemini`             | `mlflow.gemini.autolog()`    | Google Gemini API           |
+        | `azure`              | `mlflow.openai.autolog()`    | Azure OpenAI                |
+        | `bedrock`            | `mlflow.bedrock.autolog()`   | AWS Bedrock                 |
+
+        ### Tracing with an OpenShift MLflow server
+
+        To enable tracing and logging with MLflow on your OpenShift cluster, add the following environment variables to your
+        `.env` file:
+
+        ```ini
+        MLFLOW_TRACKING_URI = "https://<openshift-dashboard-url>/mlflow"
+        MLFLOW_TRACKING_TOKEN = "<your-openshift-token>"
+        MLFLOW_EXPERIMENT_NAME = "crewai-websearch-agent"
+        MLFLOW_TRACKING_INSECURE_TLS = "true"
+        MLFLOW_WORKSPACE = "default"
+        ```
+
+        **Notes:**
+
+        - `MLFLOW_TRACKING_URI` - Replace `<openshift-dashboard-url>` with your OpenShift cluster's data science gateway URL
+        - `MLFLOW_TRACKING_TOKEN` - Your openshift authentication token. It can be obtained from the openshift console.
+        - `MLFLOW_EXPERIMENT_NAME` - A descriptive name for your experiment (e.g., "CrewAI WebSearch Demo")
+        - `MLFLOW_TRACKING_INSECURE_TLS` - Set to `"true"` if your OpenShift cluster does not use trusted certificates
+        - `MLFLOW_WORKSPACE` - Project name
+
+        - Tracing is optional; if you do not set `MLFLOW_TRACKING_URI`, the application will run without MLflow logging.
+
+        - If `MLFLOW_TRACKING_URI` is set, the application will attempt to connect to the MLflow server at startup. If the
+          server is unreachable, the application will log a warning and continue running without tracing.
+
+        - You can control how long the application waits for the MLflow server by setting `MLFLOW_HEALTH_CHECK_TIMEOUT` (in
+          seconds, default: `5`).
+
+        ## Deploying to OpenShift
+
+        ### Setup
+
+        ```bash
+        cd agents/crewai/templates/websearch_agent
+        make init
+        ```
+
+        ### Configuration
+
+        Edit `.env` with your model endpoint and container image:
+
+        ```ini
+        API_KEY = your-api-key-here
+        BASE_URL = https://your-model-endpoint.com/v1
+        MODEL_ID = llama-3.1-8b-instruct
+        CONTAINER_IMAGE = quay.io/your-username/crewai-websearch-agent:latest
+        ```
+
+        **Notes:**
+
+        - `API_KEY` - your API key or contact your cluster administrator
+        - `BASE_URL` - should end with `/v1`. For local OGX, use `http://localhost:8321/v1`
+        - `MODEL_ID` - model identifier available on your endpoint
+          - **Local OGX:** requires `ollama/` prefix (e.g., `ollama/Llama3.1:8B`)
+          - **Cluster deployment:** discover available models via `curl $BASE_URL/models` or check your model serving dashboard
+        - `CONTAINER_IMAGE` – full image path where the agent container will be pushed and pulled from. The image is built
+          locally, pushed to this registry, and then deployed to OpenShift.
+
+          Format: `<registry>/<namespace>/<image-name>:<tag>`
+
+          Examples:
+
+          - Quay.io: `quay.io/your-username/crewai-websearch-agent:latest`
+          - Docker Hub: `docker.io/your-username/crewai-websearch-agent:latest`
+          - GHCR: `ghcr.io/your-org/crewai-websearch-agent:latest`
+
+          > **Note:** OpenShift must be able to pull the container image. Make the image **public**, or configure
+          an [image pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html)
+          for private registries.
+
+        ### Building the Container Image
+
+        Login to OC
+
+        ```bash
+        oc login -u "login" -p "password" https://super-link-to-cluster:111
+        ```
+
+        Login ex. Docker
+
+        ```bash
+        docker login -u='login' -p='password' quay.io
+        ```
+
+        #### Option A: Build locally and push to a registry
+
+        Requires Podman (or Docker) and a registry account (e.g., Quay.io).
+
+        ```bash
+        make build    # builds the image locally
+        make push     # pushes to the registry specified in CONTAINER_IMAGE
+        ```
+
+        #### Option B: Build in-cluster via OpenShift BuildConfig
+
+        No Podman, Docker, or registry account needed — just the `oc` CLI.
+
+        ```bash
+        make build-openshift
+        ```
+
+        After the build completes, set `CONTAINER_IMAGE` in your `.env` to the internal registry URL printed after the build.
+
+        ### Deploying
+
+        #### Preview manifests (`make dry-run`)
+
+        ```bash
+        make dry-run          # preview rendered Helm manifests (secrets redacted)
+        ```
+
+        #### Deploy (`make deploy`)
+
+        ```bash
+        make deploy
+        ```
+
+        #### Verify deployment
+
+        After deploying, the application may take about a minute to become available while the pod starts up.
+
+        The route URL is printed after `make deploy`. You can also retrieve it manually:
+
+        ```bash
+        oc get route crewai-websearch-agent -o jsonpath='{.spec.host}'
+        ```
+
+        #### Remove deployment (`make undeploy`)
+
+        ```bash
+        make undeploy
+        ```
+
+        See [OpenShift Deployment](../../../docs/openshift-deployment.md) for more details.
+
+        ## Tests
+
+        ### Unit tests
+
+        ```bash
+        make test
+        ```
+
+        ### Behavioral tests
+
+        Behavioral tests validate tool selection, response quality, latency, and reliability against a live agent. They require MLflow tracing to extract tool_calls from trace spans.
+
+        ```bash
+        CREWAI_WEBSEARCH_AGENT_URL=https://<agent-route> \
+        MLFLOW_TRACKING_URI=<mlflow-uri> \
+        MLFLOW_EXPERIMENT_NAME=<experiment> \
+        MLFLOW_TRACKING_TOKEN=$(oc whoami -t) \
+        pytest tests/behavioral/ -v
+        ```
+
+        Skip slow pass@k tests with `-m "not slow"`.
+
+        ## API Endpoints
+
+        ### POST /chat/completions
+
+        Non-streaming:
+
+        ```bash
+        curl -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "What is the best cluster hosting service?"}], "stream": false}'
+        ```
+
+        Streaming:
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "What is the best cluster hosting service?"}], "stream": true}'
+        ```
+
+        Pretty Printed Stream:
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "What is the best cluster hosting service?"}], "stream": true}' |
+           jq -R -r -j --stream 'scan("^data:(.*)")[] | fromjson.choices[0].delta.content // empty'
+        ```
+
+        ### GET /health
+
+        ```bash
+        curl http://localhost:8000/health
+        ```
+
+        ## Resources
+
+        - [CrewAI Documentation](https://docs.crewai.com/)
+        - [CrewAI Tools](https://docs.crewai.com/concepts/tools)
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/crewai/templates/websearch_agent
+      framework: crewai
+      agentType: starter_kit
+      env:
+        - name: API_KEY
+          required: true
+        - name: BASE_URL
+          required: true
+        - name: MODEL_ID
+          required: true
+        - name: PORT
+          required: false
+        - name: CONTAINER_IMAGE
+          required: false
+    - name: llamaindex-websearch-agent
+      displayName: LlamaIndex WebSearch Agent
+      description: Agent built on LlamaIndex that uses a web search tool to query the internet and augment answers.
+      readme: |
+        <div style="text-align: center;">
+
+        ![LlamaIndex Logo](/images/llamaindex_logo.svg)
+
+        # WebSearch Agent
+
+        </div>
+
+        ---
+
+        ## What this agent does
+
+        Agent built on LlamaIndex that uses a web search tool to query the internet and use the results in its answers.
+
+        ---
+
+        ## Prerequisites
+
+        - [uv](https://docs.astral.sh/uv/) — Python package manager
+        - [Podman](https://podman.io/) or [Docker](https://www.docker.com/) — for local container builds (Option A)
+        - [oc](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) — for
+          OpenShift deployment
+        - [Helm](https://helm.sh/) — for deploying to Kubernetes/OpenShift
+        - [GNU Make](https://www.gnu.org/software/make/) and a bash-compatible shell — on Windows,
+          use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (recommended)
+          or [Git Bash](https://git-scm.com/downloads)
+
+        ## Local Development
+
+        ### Initiating base
+
+        `make init` creates a `.env` file from `.env.example`. Set your environment variables in the `.env` file.
+
+        ```bash
+        cd agents/llamaindex/templates/websearch_agent
+        make init
+        ```
+
+        ### Tracing (optional)
+
+        Tracing is optional. If MLflow tracing is required, enable it by uncommenting and setting the following environment variables in the `.env` file.
+
+        #### Tracing with a local MLflow server
+
+        ```ini
+        MLFLOW_TRACKING_URI="http://localhost:5000"
+        MLFLOW_EXPERIMENT_NAME="llamaindex-websearch-agent"
+        MLFLOW_HTTP_REQUEST_TIMEOUT=2
+        MLFLOW_HTTP_REQUEST_MAX_RETRIES=0
+        ```
+
+        Then start the MLflow server in a separate terminal:
+
+        ```bash
+        # Start the MLflow server
+        uv run --extra tracing mlflow server --port 5000
+        ```
+
+        When `MLFLOW_TRACKING_URI` is set, `make run-app` and `make run-cli` will automatically install the tracing dependency.
+
+        #### Tracing with an OpenShift MLflow server
+
+        To enable tracing and logging with MLflow on your OpenShift cluster, add the following environment variables to your `.env` file:
+
+        ```ini
+        MLFLOW_TRACKING_URI="https://<openshift-dashboard-url>/mlflow"
+        MLFLOW_TRACKING_TOKEN="<your-openshift-token>"
+        MLFLOW_EXPERIMENT_NAME="llamaindex-websearch-agent"
+        MLFLOW_TRACKING_INSECURE_TLS="true"
+        MLFLOW_WORKSPACE="default"
+        ```
+
+        **Notes:**
+
+        - `MLFLOW_TRACKING_URI` - URL of your MLflow server. For local development, use `http://localhost:5000`. If using MLflow on an OpenShift cluster, replace `<openshift-dashboard-url>` with your cluster's data science gateway URL.
+        - `MLFLOW_TRACKING_TOKEN` - Required for OpenShift only. Your OpenShift authentication token, obtained from the OpenShift console.
+        - `MLFLOW_EXPERIMENT_NAME` - A descriptive name for your experiment (e.g., "LlamaIndex WebSearch Demo")
+        - `MLFLOW_TRACKING_INSECURE_TLS` - Required for OpenShift only. Set to `"true"` if your cluster does not use trusted certificates.
+        - `MLFLOW_WORKSPACE` - Required for OpenShift only. Project name.
+
+        - Tracing is optional; if you do not set `MLFLOW_TRACKING_URI`, the application will run without MLflow logging.
+
+        - If `MLFLOW_TRACKING_URI` is set, the application will attempt to connect to the MLflow server at startup. If the server is unreachable, the application will log a warning and continue running without tracing.
+
+        - You can control how long the application waits for the MLflow server by setting `MLFLOW_HEALTH_CHECK_TIMEOUT` (in seconds, default: `5`).
+
+        ### Creating environment
+
+        Now you will remove old .venv and create new. Next dependencies will be installed.
+
+        ```bash
+        make env
+        ```
+
+        ### Setup Ollama
+
+        This will install ollama if it is not installed already. Then pull needed models for local work.
+        The default model is `llama3.1:8b`. To use a different model, pass `MODEL=`:
+        `make ollama MODEL=llama3.2:3b`
+
+        ```bash
+        make ollama
+        ```
+
+        ### Run OGX server
+
+        > **Keep this terminal open** – the server needs to keep running.
+        > You should see output indicating the server started on `http://localhost:8321`.
+
+        ```bash
+        make ogx-server
+        ```
+
+        ### Run the interactive web application
+
+        > **Keep this terminal open** – the app needs to keep running.
+        > You should see output indicating the app started on `http://localhost:8000`.
+
+        ```bash
+        cd agents/llamaindex/templates/websearch_agent
+        make run-app           # fails if port is already in use and print steps TO-DO
+        ```
+
+        ### Interactive CLI
+
+        For terminal-based testing without a browser:
+
+        ```bash
+        cd agents/llamaindex/templates/websearch_agent
+        make run-cli
+        ```
+
+        This launches an interactive prompt where you can pick predefined questions or type your own. Tool calls and results are
+        displayed inline with colored output.
+
+        ## Deploying to OpenShift
+
+        ### Setup
+
+        ```bash
+        cd agents/llamaindex/templates/websearch_agent
+        make init
+        ```
+
+        ### Configuration
+
+        Edit `.env` with your model endpoint and container image:
+
+        ```ini
+        API_KEY = your-api-key-here
+        BASE_URL = https://your-model-endpoint.com/v1
+        MODEL_ID = llama-3.1-8b-instruct
+        CONTAINER_IMAGE = quay.io/your-username/llamaindex-websearch-agent:latest
+        ```
+
+        **Notes:**
+
+        - `API_KEY` - your API key or contact your cluster administrator
+        - `BASE_URL` - should end with `/v1`. For local OGX, use `http://localhost:8321/v1`
+        - `MODEL_ID` - model identifier available on your endpoint
+          - **Local OGX:** requires `ollama/` prefix (e.g., `ollama/Llama3.1:8B`)
+          - **Cluster deployment:** discover available models via `curl $BASE_URL/models` or check your model serving dashboard
+        - `CONTAINER_IMAGE` – full image path where the agent container will be pushed and pulled from. The image is built
+          locally, pushed to this registry, and then deployed to OpenShift.
+
+          Format: `<registry>/<namespace>/<image-name>:<tag>`
+
+          Examples:
+
+          - Quay.io: `quay.io/your-username/llamaindex-websearch-agent:latest`
+          - Docker Hub: `docker.io/your-username/llamaindex-websearch-agent:latest`
+          - GHCR: `ghcr.io/your-org/llamaindex-websearch-agent:latest`
+
+          > **Note:** OpenShift must be able to pull the container image. Make the image **public**, or configure
+          an [image pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html)
+          for private registries.
+
+        ### Building the Container Image
+
+        Login to OC
+
+        ```bash
+        oc login -u "login" -p "password" https://super-link-to-cluster:111
+        ```
+
+        Login ex. Docker
+
+        ```bash
+        docker login -u='login' -p='password' quay.io
+        ```
+
+        #### Option A: Build locally and push to a registry
+
+        Requires Podman (or Docker) and a registry account (e.g., Quay.io).
+
+        ```bash
+        make build    # builds the image locally
+        make push     # pushes to the registry specified in CONTAINER_IMAGE
+        ```
+
+        #### Option B: Build in-cluster via OpenShift BuildConfig
+
+        No Podman, Docker, or registry account needed — just the `oc` CLI.
+
+        ```bash
+        make build-openshift
+        ```
+
+        After the build completes, set `CONTAINER_IMAGE` in your `.env` to the internal registry URL printed after the build.
+
+        ### Deploying
+
+        #### Preview manifests (`make dry-run`)
+
+        ```bash
+        make dry-run          # preview rendered Helm manifests (secrets redacted)
+        ```
+
+        #### Deploy (`make deploy`)
+
+        ```bash
+        make deploy
+        ```
+
+        #### Verify deployment
+
+        After deploying, the application may take about a minute to become available while the pod starts up.
+
+        The route URL is printed after `make deploy`. You can also retrieve it manually:
+
+        ```bash
+        oc get route llamaindex-websearch-agent -o jsonpath='{.spec.host}'
+        ```
+
+        #### Remove deployment (`make undeploy`)
+
+        ```bash
+        make undeploy
+        ```
+
+        See [OpenShift Deployment](../../../docs/openshift-deployment.md) for more details.
+
+        ## Tests
+
+        ```bash
+        make test
+        ```
+
+        ## API Endpoints
+
+        ### POST /chat/completions
+
+        Non-streaming:
+
+        ```bash
+        curl -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "Which company is considered the best?"}], "stream": false}'
+        ```
+
+        Streaming:
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "Which company is considered the best?"}], "stream": true}'
+        ```
+
+        Pretty Printed Stream:
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "Which company is considered the best?"}], "stream": true}' |
+           jq -R -r -j --stream 'scan("^data:(.*)")[] | fromjson.choices[0].delta.content // empty'
+        ```
+
+        ### GET /health
+
+        ```bash
+        curl http://localhost:8000/health
+        ```
+
+        ## Behavioral Tests
+
+        Behavioral eval suite that validates tool usage, response quality, latency, and reliability over HTTP.
+
+        ```bash
+        # From the repo root (not the agent directory)
+        cd /path/to/agentic-starter-kits
+
+        # Collect tests
+        uv run --extra test python -m pytest agents/llamaindex/templates/websearch_agent/tests/behavioral/ --collect-only
+
+        # Run against a deployed agent (with MLflow tracing)
+        LLAMAINDEX_WEBSEARCH_AGENT_URL=https://<route> \
+        MLFLOW_TRACKING_URI=<uri> \
+        MLFLOW_EXPERIMENT_NAME=<experiment> \
+        MLFLOW_TRACKING_TOKEN=$(oc whoami -t) \
+        MLFLOW_WORKSPACE=<namespace> \
+        MLFLOW_TRACKING_INSECURE_TLS=true \
+        uv run --extra test python -m pytest agents/llamaindex/templates/websearch_agent/tests/behavioral/ -v
+        ```
+
+        Tests must run from the repo root because test dependencies (`pytest-asyncio`, harness package) are declared in the root `pyproject.toml`.
+
+        ## Resources
+
+        - [LlamaIndex Documentation](https://docs.llamaindex.ai/)
+        - [LlamaIndex Workflows](https://docs.llamaindex.ai/en/stable/module_guides/workflow/)
+        - [OGX Documentation](https://ogx-ai.github.io/docs/)
+        - [Ollama Documentation](https://ollama.com/docs)
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/llamaindex/templates/websearch_agent
+      framework: llamaindex
+      agentType: starter_kit
+      env:
+        - name: API_KEY
+          required: true
+        - name: BASE_URL
+          required: true
+        - name: MODEL_ID
+          required: true
+        - name: PORT
+          required: false
+        - name: CONTAINER_IMAGE
+          required: false
+    - name: openai-responses-agent
+      displayName: OpenAI Responses Agent
+      description: 'Minimal agent with no framework: only the OpenAI Python client and an Action/Observation loop with tools.'
+      readme: |
+        <div style="text-align: center;">
+
+        ![OpenAI Logo](/images/openai_logo.svg)
+
+        # Pure Responses Agent
+
+        </div>
+
+        ---
+
+        ## What this agent does
+
+        Minimal agent with no framework: only the OpenAI Python client and an Action/Observation loop with tools. Requires the
+        [OpenAI Responses API](https://developers.openai.com/api/reference/resources/responses/methods/create) — works with OpenAI or any
+        endpoint that supports the Responses API.
+
+        ---
+
+        ## Prerequisites
+
+        - [uv](https://docs.astral.sh/uv/) — Python package manager
+        - [Podman](https://podman.io/) or [Docker](https://www.docker.com/) — for local container builds (Option A)
+        - [oc](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) — for
+          OpenShift deployment
+        - [Helm](https://helm.sh/) — for deploying to Kubernetes/OpenShift
+        - [GNU Make](https://www.gnu.org/software/make/) and a bash-compatible shell — on Windows,
+          use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (recommended)
+          or [Git Bash](https://git-scm.com/downloads)
+
+        ## Local Development
+
+        > **Note:** This agent uses the [OpenAI Responses API](https://developers.openai.com/api/reference/resources/responses/methods/create),
+        > which is specific to OpenAI. It does not use Ollama or OGX for local model serving.
+
+        ### Initiating base
+
+        `make init` creates a `.env` file from `.env.example`. Set your environment variables in the `.env` file.
+
+        ```bash
+        cd agents/vanilla_python/templates/openai_responses_agent
+        make init
+        ```
+
+        ### Tracing (optional)
+
+        Tracing is optional. If MLflow tracing is required, enable it by uncommenting and setting the following environment variables in the `.env` file.
+
+        #### Tracing with a local MLflow server
+
+        ```ini
+        MLFLOW_TRACKING_URI="http://localhost:5000"
+        MLFLOW_EXPERIMENT_NAME="openai-responses-agent"
+        MLFLOW_HTTP_REQUEST_TIMEOUT=2
+        MLFLOW_HTTP_REQUEST_MAX_RETRIES=0
+        ```
+
+        Then start the MLflow server in a separate terminal:
+
+        ```bash
+        # Start the MLflow server
+        uv run --extra tracing mlflow server --port 5000
+        ```
+
+        When `MLFLOW_TRACKING_URI` is set, `make run-app` and `make run-cli` will automatically install the tracing dependency.
+
+        #### Tracing with an OpenShift MLflow server
+
+        To enable tracing and logging with MLflow on your OpenShift cluster, add the following environment variables to your `.env` file:
+
+        ```ini
+        MLFLOW_TRACKING_URI="https://<openshift-dashboard-url>/mlflow"
+        MLFLOW_TRACKING_TOKEN="<your-openshift-token>"
+        MLFLOW_EXPERIMENT_NAME="openai-responses-agent"
+        MLFLOW_TRACKING_INSECURE_TLS="true"
+        MLFLOW_WORKSPACE="default"
+        ```
+
+        **Notes:**
+
+        - `MLFLOW_TRACKING_URI` - URL of your MLflow server. For local development, use `http://localhost:5000`. If using MLflow on an OpenShift cluster, replace `<openshift-dashboard-url>` with your cluster's data science gateway URL.
+        - `MLFLOW_TRACKING_TOKEN` - Required for OpenShift only. Your OpenShift authentication token, obtained from the OpenShift console.
+        - `MLFLOW_EXPERIMENT_NAME` - A descriptive name for your experiment (e.g., "OpenAI Responses Demo")
+        - `MLFLOW_TRACKING_INSECURE_TLS` - Required for OpenShift only. Set to `"true"` if your cluster does not use trusted certificates.
+        - `MLFLOW_WORKSPACE` - Required for OpenShift only. Project name.
+
+        - Tracing is optional; if you do not set `MLFLOW_TRACKING_URI`, the application will run without MLflow logging.
+
+        - If `MLFLOW_TRACKING_URI` is set, the application will attempt to connect to the MLflow server at startup. If the server is unreachable, the application will log a warning and continue running without tracing.
+
+        - You can control how long the application waits for the MLflow server by setting `MLFLOW_HEALTH_CHECK_TIMEOUT` (in seconds, default: `5`).
+
+        ### Creating environment
+
+        Now you will remove old .venv and create new. Next dependencies will be installed.
+
+        ```bash
+        make env
+        ```
+
+        ### Run the interactive web application
+
+        > **Keep this terminal open** – the app needs to keep running.
+        > You should see output indicating the app started on `http://localhost:8000`.
+
+        ```bash
+        cd agents/vanilla_python/templates/openai_responses_agent
+        make run-app           # fails if port is already in use and print steps TO-DO
+        ```
+
+        ### Interactive CLI
+
+        For terminal-based testing without a browser:
+
+        ```bash
+        cd agents/vanilla_python/templates/openai_responses_agent
+        make run-cli
+        ```
+
+        This launches an interactive prompt where you can pick predefined questions or type your own. Tool calls and results are
+        displayed inline with colored output.
+
+        ## Deploying to OpenShift
+
+        ### Setup
+
+        ```bash
+        cd agents/vanilla_python/templates/openai_responses_agent
+        make init
+        ```
+
+        ### Configuration
+
+        Edit `.env` with your model endpoint and container image:
+
+        ```ini
+        API_KEY = your-openai-api-key
+        BASE_URL = https://api.openai.com/v1
+        MODEL_ID = gpt-4o-mini
+        CONTAINER_IMAGE = quay.io/your-username/openai-responses-agent:latest
+        ```
+
+        **Notes:**
+
+        - `API_KEY` - your OpenAI API key (or `not-needed` for local OGX)
+        - `BASE_URL` - should end with `/v1`. For local OGX, use `http://localhost:8321/v1`
+        - `MODEL_ID` - model identifier available on your endpoint
+          - **Local OGX:** requires `ollama/` prefix (e.g., `ollama/Llama3.1:8B`)
+          - **Cluster deployment:** discover available models via `curl $BASE_URL/models` or check your model serving dashboard
+        - `CONTAINER_IMAGE` – full image path where the agent container will be pushed and pulled from. The image is built
+          locally, pushed to this registry, and then deployed to OpenShift.
+
+          Format: `<registry>/<namespace>/<image-name>:<tag>`
+
+          Examples:
+
+          - Quay.io: `quay.io/your-username/openai-responses-agent:latest`
+          - Docker Hub: `docker.io/your-username/openai-responses-agent:latest`
+          - GHCR: `ghcr.io/your-org/openai-responses-agent:latest`
+
+          > **Note:** OpenShift must be able to pull the container image. Make the image **public**, or configure
+          an [image pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html)
+          for private registries.
+
+        ### Building the Container Image
+
+        Login to OC
+
+        ```bash
+        oc login -u "login" -p "password" https://super-link-to-cluster:111
+        ```
+
+        Login ex. Docker
+
+        ```bash
+        docker login -u='login' -p='password' quay.io
+        ```
+
+        #### Option A: Build locally and push to a registry
+
+        Requires Podman (or Docker) and a registry account (e.g., Quay.io).
+
+        ```bash
+        make build    # builds the image locally
+        make push     # pushes to the registry specified in CONTAINER_IMAGE
+        ```
+
+        #### Option B: Build in-cluster via OpenShift BuildConfig
+
+        No Podman, Docker, or registry account needed — just the `oc` CLI.
+
+        ```bash
+        make build-openshift
+        ```
+
+        After the build completes, set `CONTAINER_IMAGE` in your `.env` to the internal registry URL printed after the build.
+
+        ### Deploying
+
+        #### Preview manifests (`make dry-run`)
+
+        ```bash
+        make dry-run          # preview rendered Helm manifests (secrets redacted)
+        ```
+
+        #### Deploy (`make deploy`)
+
+        ```bash
+        make deploy
+        ```
+
+        #### Verify deployment
+
+        After deploying, the application may take about a minute to become available while the pod starts up.
+
+        The route URL is printed after `make deploy`. You can also retrieve it manually:
+
+        ```bash
+        oc get route openai-responses-agent -o jsonpath='{.spec.host}'
+        ```
+
+        #### Remove deployment (`make undeploy`)
+
+        ```bash
+        make undeploy
+        ```
+
+        See [OpenShift Deployment](../../../docs/openshift-deployment.md) for more details.
+
+        ## Tests
+
+        ```bash
+        make test
+        ```
+
+        ## API Endpoints
+
+        ### POST /chat/completions
+
+        Non-streaming:
+
+        ```bash
+        curl -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "How much does a Lenovo Laptop cost and what are the reviews?"}], "stream": false}'
+        ```
+
+        Streaming:
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "How much does a Lenovo Laptop cost and what are the reviews?"}], "stream": true}'
+        ```
+
+        Pretty Printed Stream:
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "How much does a Lenovo Laptop cost and what are the reviews?"}], "stream": true}' |
+           jq -R -r -j 'scan("^data:(.*)") | .[0] | select(. != " [DONE]") | fromjson.choices[0].delta.content // empty'
+        ```
+
+        ### GET /health
+
+        ```bash
+        curl http://localhost:8000/health
+        ```
+
+        ## Resources
+
+        - [OpenAI Python Client](https://github.com/openai/openai-python)
+        - [OpenAI Responses API](https://developers.openai.com/api/reference/resources/responses/methods/create)
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/vanilla_python/templates/openai_responses_agent
+      framework: vanilla_python
+      agentType: starter_kit
+      env:
+        - name: API_KEY
+          required: true
+        - name: BASE_URL
+          required: true
+        - name: MODEL_ID
+          required: true
+        - name: PORT
+          required: false
+        - name: CONTAINER_IMAGE
+          required: false
+    - name: autogen-mcp-agent
+      displayName: AutoGen Agent (MCP)
+      description: AutoGen-based agent with MCP tools over SSE. Connects to an MCP server, loads tools dynamically, and answers user questions via an OpenAI-compatible API.
+      readme: |
+        <div style="text-align: center;">
+
+        ![AutoGen Logo](/images/autogen_logo.svg)
+
+        # AutoGen Agent (MCP)
+
+        </div>
+
+        ---
+
+        ## What this agent does
+
+        An AutoGen-based agent with MCP (Model Context Protocol) tools over SSE. It connects to an MCP server, loads tools
+        dynamically (e.g. churn prediction, deployment), and answers user questions via an OpenAI-compatible
+        `POST /chat/completions` API. Built with AutoGen `AssistantAgent` and `autogen_ext.tools.mcp`.
+
+        **Key features:**
+
+        - Discovers and loads tools from an MCP server at startup
+        - Uses `reflect_on_tool_use=True` so the LLM reasons about tool results before responding
+        - Supports both streaming (SSE) and non-streaming responses (streaming auto-adjusts when MLflow tracing is enabled; see [Tracing](#tracing-optional) section)
+        - Includes an interactive web playground with an MCP tools panel
+        - Extends OpenAI streaming with `mcp.tool_usage` events and `tool_invocations` in JSON responses
+
+        ---
+
+        ## Prerequisites
+
+        - [uv](https://docs.astral.sh/uv/) — Python package manager
+        - [Podman](https://podman.io/) or [Docker](https://www.docker.com/) — for local container builds (Option A)
+        - [oc](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) — for OpenShift deployment
+        - [Helm](https://helm.sh/) — for deploying to Kubernetes/OpenShift
+        - [GNU Make](https://www.gnu.org/software/make/) and a bash-compatible shell — on Windows, use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (recommended) or [Git Bash](https://git-scm.com/downloads)
+        - **MCP Server** — this agent requires a running MCP server (included in `mcp_automl_template/`)
+
+        ## Deploying Locally
+
+        ### Setup
+
+        ```bash
+        cd agents/autogen/templates/mcp_agent
+        make init        # creates .env from .env.example
+        ```
+
+        ### Install dependencies
+
+        ```bash
+        make env
+        ```
+
+        ### Configure your model
+
+        Edit `.env` to point the agent at an LLM. Choose **one** of the two options below.
+
+        #### Option A: Local model (Ollama + OGX)
+
+        Set the following in `.env`:
+
+        ```ini
+        API_KEY=not-needed
+        BASE_URL=http://localhost:11434/v1
+        MODEL_ID=llama3.1:8b
+        ```
+
+        Then install Ollama and pull the model:
+
+        ```bash
+        make ollama                    # default model: llama3.1:8b
+        make ollama MODEL=llama3.2:3b  # or specify a different model
+        ```
+
+        Start the OGX server (keep this terminal open):
+
+        ```bash
+        make ogx-server
+        ```
+
+        > You should see output indicating the server started on `http://localhost:8321`.
+
+        #### Option B: Remote model
+
+        Set the following in `.env`:
+
+        ```ini
+        API_KEY=your-api-key-here
+        BASE_URL=https://your-model-endpoint.com/v1
+        MODEL_ID=llama-3.1-8b-instruct
+        ```
+
+        - `API_KEY` - your API key or contact your cluster administrator
+        - `BASE_URL` - should end with `/v1`. For local OGX, use `http://localhost:8321/v1`
+        - `MODEL_ID` - model identifier available on your endpoint. For local OGX, requires `ollama/` prefix (e.g., `ollama/Llama3.1:8B`)
+
+        ### MCP Configuration
+
+        The agent can connect to any MCP server that supports SSE transport. By default it points to the bundled `mcp_automl_template` server(no configuration needed):
+
+        | Environment | Default `MCP_SERVER_URL` | How it's set |
+        |-------------|--------------------------|--------------|
+        | Local (`make run-app`) | `http://127.0.0.1:8080/sse` | Makefile fallback |
+        | OpenShift (`make deploy`) | `http://mcp-automl:8080/sse` | `values.yaml` (in-cluster service DNS) |
+
+        To connect to an external MCP server, set `MCP_SERVER_URL` in your `.env`:
+
+        ```ini
+        MCP_SERVER_URL=https://your-external-mcp-server.example.com/sse
+        ```
+
+        #### DNS Rebinding Protection
+
+        MCP SDK ≥1.x enables host-header DNS rebinding protection by default. When running the MCP server behind an
+        OpenShift Route (or any reverse proxy that rewrites the `Host` header), the MCP server may reject requests.
+        To disable this protection, uncomment and set in your `.env`:
+
+        ```ini
+        DISABLE_DNS_REBINDING_PROTECTION=true
+        ```
+
+        This is passed to the MCP server deployment (`make deploy-mcp`). Leave it commented out (protection enabled)
+        unless you encounter host-header mismatch errors.
+
+        #### MCP AutoML Server Variables
+
+        If you plan to deploy the MCP AutoML server to OpenShift (`make deploy-mcp`) with tools that call an ML model serving endpoint (e.g. churn prediction via KServe/AutoML), set these in your `.env`:
+
+        ```ini
+        DEPLOYMENT_URL=https://your-model-serving-endpoint.com/v1/models/your-model:predict
+        DEPLOYMENT_TOKEN=your-model-serving-bearer-token
+        ```
+
+        - `DEPLOYMENT_URL` — URL of the ML model serving endpoint called by MCP tools at runtime
+        - `DEPLOYMENT_TOKEN` — Bearer token for authenticating with the model serving endpoint
+
+        ### Tracing (optional)
+
+        Tracing is optional. If MLflow tracing is required, enable it by uncommenting and setting the following environment variables in the `.env` file.
+
+        #### Tracing with a local MLflow server
+
+        ```ini
+        MLFLOW_TRACKING_URI="http://localhost:5000"
+        MLFLOW_EXPERIMENT_NAME="autogen-mcp-agent"
+        MLFLOW_HTTP_REQUEST_TIMEOUT=2
+        MLFLOW_HTTP_REQUEST_MAX_RETRIES=0
+        ```
+
+        Then start the MLflow server in a separate terminal:
+
+        ```bash
+        # Start the MLflow server
+        uv run --extra tracing mlflow server --port 5000
+        ```
+
+        When `MLFLOW_TRACKING_URI` is set, `make run-app` will automatically install the tracing dependency.
+
+        #### Tracing with an OpenShift MLflow server
+
+        To enable tracing and logging with MLflow on your OpenShift cluster, add the following environment variables to your `.env` file:
+
+        ```ini
+        MLFLOW_TRACKING_URI="https://<openshift-dashboard-url>/mlflow"
+        MLFLOW_TRACKING_TOKEN="<your-openshift-token>"
+        MLFLOW_EXPERIMENT_NAME="autogen-mcp-agent"
+        MLFLOW_TRACKING_INSECURE_TLS="true"
+        MLFLOW_WORKSPACE="default"
+        ```
+
+        **Notes:**
+
+        - `MLFLOW_TRACKING_URI` - URL of your MLflow server. For local development, use `http://localhost:5000`. If using MLflow on an OpenShift cluster, replace `<openshift-dashboard-url>` with your cluster's data science gateway URL.
+        - `MLFLOW_TRACKING_TOKEN` - Required for OpenShift only. Your OpenShift authentication token, obtained from the OpenShift console.
+        - `MLFLOW_EXPERIMENT_NAME` - A descriptive name for your experiment (e.g., "AutoGen MCP Demo")
+        - `MLFLOW_TRACKING_INSECURE_TLS` - Required for OpenShift only. Set to `"true"` if your cluster does not use trusted certificates.
+        - `MLFLOW_WORKSPACE` - Required for OpenShift only. Project name.
+
+        - Tracing is optional; if you do not set `MLFLOW_TRACKING_URI`, the application will run without MLflow logging.
+
+        - If `MLFLOW_TRACKING_URI` is set, the application will attempt to connect to the MLflow server at startup. If the server is unreachable, the application will log a warning and continue running without tracing.
+
+        - You can control how long the application waits for the MLflow server by setting `MLFLOW_HEALTH_CHECK_TIMEOUT` (in seconds, default: `5`).
+
+        #### Streaming and tracing
+
+        `mlflow.autogen.autolog()` does not support AutoGen's streaming APIs (`run_stream`, `create_stream`) as of now. To handle this, streaming is **auto-detected**:
+
+        - When `MLFLOW_TRACKING_URI` is **not set** → streaming is enabled (playground works)
+        - When `MLFLOW_TRACKING_URI` is **set** → streaming is disabled (complete MLflow traces)
+
+        You can always override this by setting `MODEL_CLIENT_STREAM` explicitly in your `.env`:
+
+        ```ini
+        MODEL_CLIENT_STREAM=true   # force streaming on (playground works, traces incomplete)
+        MODEL_CLIENT_STREAM=false  # force streaming off (complete traces, playground won't display responses)
+        ```
+
+        When streaming is enabled, traces will be incomplete — LLM spans will be missing and remaining spans (TOOL) will be orphaned without a parent AGENT span. Once MLflow adds native support for AutoGen streaming, traces will work automatically without any code changes.
+
+        ### Running the Agent
+
+        This agent requires **two terminals** — one for the MCP server and one for the agent itself.
+
+        #### Terminal 1 — Start MCP server
+
+        The MCP server must be running before the agent starts:
+
+        ```bash
+        make run-mcp
+        ```
+
+        This starts the MCP AutoML server on port 8080.
+
+        #### Terminal 2 — Start agent
+
+        ```bash
+        make run-app           # fails if port is already in use
+        make run-app-fresh     # kills existing process on port, then starts
+        ```
+
+        The agent starts on port 8000. Open [http://localhost:8000](http://localhost:8000) in your browser. A green dot in
+        the header means the agent is connected and ready.
+
+        The playground includes an **MCP tools** panel that shows which tools were invoked for the last reply, along with
+        their arguments and results. You can also open [http://localhost:8000/docs](http://localhost:8000/docs) for the
+        Swagger UI to explore and test the API interactively.
+
+        #### Quick test
+
+        ```bash
+        curl -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"message": "What is 2+7? Use a tool!"}'
+        ```
+
+        #### Interactive MCP chat (optional)
+
+        You can also interact with the MCP tools directly via a LangGraph agent (bypasses the AutoGen agent):
+
+        ```bash
+        make interact-mcp
+        ```
+
+        ## Deploying to OpenShift
+
+        > **Before you begin:** Log in to OpenShift (`oc login`) and, if using local build + push, your container registry (`podman login`).
+        > See [OpenShift Deployment](../../../docs/openshift-deployment.md) for full prerequisites and step-by-step instructions.
+
+        ### Step 1: Deploy the MCP server
+
+        The MCP AutoML server must be deployed before the agent. Make sure `DEPLOYMENT_URL` and
+        `DEPLOYMENT_TOKEN` are set in your `.env`, then run:
+
+        ```bash
+        make deploy-mcp
+        ```
+
+        This builds the MCP server image in-cluster via OpenShift BuildConfig and deploys it using the shared Helm chart. The Route URL is printed on success. See `mcp_automl_template/README.md` for details.
+
+        ### Step 2: Build the agent container image
+
+        #### Option A: Build locally and push to a registry
+
+        Requires Podman (or Docker) and a registry account (e.g., Quay.io).
+
+        ```bash
+        make build    # builds the image locally
+        make push     # pushes to the registry specified in CONTAINER_IMAGE
+        ```
+
+        #### Option B: Build in-cluster via OpenShift BuildConfig
+
+        No Podman, Docker, or registry account needed — just the `oc` CLI.
+
+        ```bash
+        make build-openshift
+        ```
+
+        After the build completes, set `CONTAINER_IMAGE` in your `.env` to the internal registry URL printed after the build.
+
+        ### Step 3: Deploy the agent
+
+        Edit `.env` with your model endpoint and container image:
+
+        ```ini
+        API_KEY=your-api-key-here
+        BASE_URL=https://your-model-endpoint.com/v1
+        MODEL_ID=llama-3.1-8b-instruct
+        CONTAINER_IMAGE=quay.io/your-username/autogen-mcp-agent:latest
+        ```
+
+        **Notes:**
+
+        - `API_KEY` - your API key or contact your cluster administrator
+        - `BASE_URL` - should end with `/v1`. For local OGX, use `http://localhost:8321/v1`
+        - `MODEL_ID` - model identifier available on your endpoint
+          - **Local OGX:** requires `ollama/` prefix (e.g., `ollama/Llama3.1:8B`)
+          - **Cluster deployment:** discover available models via `curl $BASE_URL/models` or check your model serving dashboard
+        - `CONTAINER_IMAGE` – full image path where the agent container will be pushed and pulled from. The image is built
+          locally, pushed to this registry, and then deployed to OpenShift.
+
+          Format: `<registry>/<namespace>/<image-name>:<tag>`
+
+          Examples:
+
+          - Quay.io: `quay.io/your-username/autogen-mcp-agent:latest`
+          - Docker Hub: `docker.io/your-username/autogen-mcp-agent:latest`
+          - GHCR: `ghcr.io/your-org/autogen-mcp-agent:latest`
+
+        #### Preview manifests
+
+        ```bash
+        make dry-run          # preview agent Helm manifests (secrets redacted)
+        make dry-run-mcp      # preview MCP server Helm manifests
+        ```
+
+        #### Deploy (`make deploy`)
+
+        ```bash
+        make deploy
+        ```
+
+        The agent's `MCP_SERVER_URL` defaults to `http://mcp-automl:8080/sse` (in-cluster DNS), so it will automatically
+        connect to the MCP server deployed in Step 1.
+
+        #### Verify deployment
+
+        After deploying, the application may take about a minute to become available while the pod starts up.
+
+        The route URL is printed after `make deploy`. You can also retrieve it manually:
+
+        ```bash
+        oc get route autogen-mcp-agent -o jsonpath='{.spec.host}'
+        ```
+
+        #### Remove deployment (`make undeploy`)
+
+        ```bash
+        make undeploy
+        ```
+
+        > **Note:** `make undeploy` removes only the agent. To also remove the MCP server:
+        >
+        > ```bash
+        > make undeploy-mcp
+        > ```
+
+        ## API Endpoints
+
+        ### POST /chat/completions
+
+        You can use either `"message": "..."` (shortcut) or `"messages": [...]` (OpenAI format).
+
+        #### Non-streaming
+
+        ```bash
+        curl -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"message": "What is 17 + 25? Use your tools to compute it."}'
+        ```
+
+        ```bash
+        curl -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "Predict churn for this customer: Male, 12 months tenure, fiber optic, month-to-month contract, electronic check, monthly 70.35, total 800.40."}], "stream": false}'
+        ```
+
+        Non-streaming responses include a `tool_invocations` array with each tool's `name`, `arguments`, `result`, and
+        `is_error` status.
+
+        #### Streaming
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "What is 2+2? Use a tool if needed."}], "stream": true}'
+        ```
+
+        Streaming responses follow the OpenAI SSE format (`chat.completion.chunk` events). If MCP tools were used, an extra
+        SSE event with `"object": "mcp.tool_usage"` is sent before `[DONE]`:
+
+        ```json
+        data: {"object": "mcp.tool_usage", "tools": [{"name": "invoke_churn", "arguments": {...}, "result": "...", "is_error": false}]}
+        ```
+
+        This is an extension to the OpenAI streaming protocol — clients can safely ignore it.
+
+        #### Pretty Printed Stream
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "What is 17 + 25? Use your tools."}], "stream": true}' |
+           jq -R -r -j --stream 'scan("^data:(.*)")[] | fromjson.choices[0].delta.content // empty'
+        ```
+
+        ### GET /health
+
+        ```bash
+        curl http://localhost:8000/health
+        ```
+
+        Returns `200` with `"status": "healthy"` when the MCP-backed agent is ready; `503` with `"status": "not_ready"`
+        until initialization completes.
+
+        ---
+
+        ## Testing
+
+        ### Behavioral tests
+
+        Behavioral tests validate tool usage, response quality, latency, and reliability against a live deployed agent.
+
+        ```bash
+        AUTOGEN_MCP_AGENT_URL=https://<agent-route> \
+        MLFLOW_TRACKING_URI=https://<mlflow-url>/mlflow \
+        MLFLOW_EXPERIMENT_NAME=<experiment> \
+        MLFLOW_TRACKING_TOKEN=$(oc whoami -t) \
+        pytest agents/autogen/templates/mcp_agent/tests/behavioral/ -v
+        ```
+
+        The tests cover only the `add` and `sub` tools. The `invoke_churn` tool is registered on the MCP server but behavioral tests exclude it because the churn prediction backend requires an external AutoGluon model deployment (trained artifact in S3 + KServe InferenceService + AutoGluon ServingRuntime) that is not in this repo or on the test cluster. See `mcp_automl_template/AUTOML_DEPLOYMENT.md` for full setup.
+
+        All behavioral tests use `stream=False` because the agent's non-streaming `ChatResponse` includes `tool_invocations[]` and `messages[]` explicitly. The streaming mode emits tool usage via a custom `mcp.tool_usage` SSE event that the shared harness does not parse.
+
+        ---
+
+        ## Architecture
+
+        This agent is built on:
+
+        - **AutoGen `AssistantAgent`** — reasoning and tool selection via an LLM (OpenAI-compatible API)
+        - **MCP SSE transport** (`autogen_ext.tools.mcp`) — connects to an MCP server over Server-Sent Events
+        - **Tool discovery** — tools are loaded dynamically from the MCP server at startup (e.g. `invoke_churn`, `add`, `multiply`)
+        - **`reflect_on_tool_use=True`** — the LLM reviews tool results and formulates a final answer
+        - **FastAPI** — serves the `/chat/completions` endpoint with both streaming and non-streaming modes
+
+        ---
+
+        ## MCP AutoML Server
+
+        The MCP AutoML server (`mcp_automl_template/`) provides the tools that this agent uses. It exposes machine learning
+        tools (e.g. churn prediction) via the Model Context Protocol over SSE.
+
+        See [`mcp_automl_template/README.md`](mcp_automl_template/README.md) for setup, tool configuration, and deployment
+        instructions.
+
+        ---
+
+        ## Documentation and references
+
+        - [AutoGen](https://microsoft.github.io/autogen/)
+        - [MCP (Model Context Protocol)](https://modelcontextprotocol.io/)
+        - [OGX Documentation](https://ogx-ai.github.io/docs/)
+        - MCP server in this repo: `mcp_automl_template/` (README, tool configuration, deploy)
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/autogen/templates/mcp_agent
+      framework: autogen
+      agentType: starter_kit
+      env:
+        - name: API_KEY
+          required: true
+        - name: BASE_URL
+          required: true
+        - name: MODEL_ID
+          required: true
+        - name: PORT
+          required: false
+        - name: CONTAINER_IMAGE
+          required: false
+        - name: MCP_SERVER_URL
+          required: false
+    - name: google-adk-agent
+      displayName: Google ADK Agent
+      description: General-purpose agent using Google ADK 2.0 with LiteLLM to route inference through an OGX-compatible endpoint.
+      readme: |
+        <div style="text-align: center;">
+
+        <img src="/images/adk_logo.png" alt="Google ADK logo" width="100" height="100">
+
+        # Google ADK 2.0 Agent
+
+        </div>
+
+        ---
+
+        ## What this agent does
+
+        General-purpose agent using Google Agent Development Kit (ADK) 2.0 with a web search tool. It uses the LiteLLM model
+        connector to route inference through a OGX server's OpenAI-compatible API endpoint.
+
+        ---
+
+        ## Prerequisites
+
+        - [uv](https://docs.astral.sh/uv/) — Python package manager
+        - [Podman](https://podman.io/) or [Docker](https://www.docker.com/) — for local container builds (Option A)
+        - [oc](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) — for
+          OpenShift deployment
+        - [Helm](https://helm.sh/) — for deploying to Kubernetes/OpenShift
+        - [GNU Make](https://www.gnu.org/software/make/) and a bash-compatible shell — on Windows,
+          use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (recommended)
+          or [Git Bash](https://git-scm.com/downloads)
+
+        ## Local Development
+
+        ### Initiating base
+
+        Here you copy .env.example file into .env
+
+        ```bash
+        cd agents/google/templates/adk
+        make init
+        ```
+
+        Edit `.env` with your configuration, then:
+
+        ### Creating environment
+
+        Now you will remove old .venv and create new. Next dependencies will be installed.
+
+        ```bash
+        make env
+        ```
+
+        ### Setup Ollama
+
+        This will install ollama if it is not installed already. Then pull needed models for local work.
+        The default model is `llama3.1:8b`. To use a different model, pass `MODEL=`:
+        `make ollama MODEL=llama3.2:3b`
+
+        ```bash
+        make ollama
+        ```
+
+        ### Run OGX server
+
+        > **Keep this terminal open** – the server needs to keep running.
+        > You should see output indicating the server started on `http://localhost:8321`.
+
+        ```bash
+        make ogx-server
+        ```
+
+        ### Run the interactive web application
+
+        > **Keep this terminal open** – the app needs to keep running.
+        > You should see output indicating the app started on `http://localhost:8000`.
+
+        ```bash
+        cd agents/google/templates/adk
+        make run-app           # fails if port is already in use and print steps TO-DO
+        ```
+
+        ### Interactive CLI
+
+        For terminal-based testing without a browser:
+
+        ```bash
+        cd agents/google/templates/adk
+        make run-cli
+        ```
+
+        ## Deploying to OpenShift
+
+        ### Setup
+
+        ```bash
+        cd agents/google/templates/adk
+        make init
+        ```
+
+        ### Configuration
+
+        Edit `.env` with your model endpoint and container image:
+
+        ```ini
+        API_KEY = your-api-key-here
+        BASE_URL = https://your-model-endpoint.com/v1
+        MODEL_ID = llama-3.1-8b-instruct
+        CONTAINER_IMAGE = quay.io/your-username/google-adk-agent:latest
+        ```
+
+        **Notes:**
+
+        - `API_KEY` - your API key or contact your cluster administrator
+        - `BASE_URL` - should end with `/v1`. For local OGX, use `http://localhost:8321/v1`
+        - `MODEL_ID` - model identifier available on your endpoint
+          - **Local OGX:** requires `ollama/` prefix (e.g., `ollama/Llama3.1:8B`)
+          - **Cluster deployment:** discover available models via `curl $BASE_URL/models` or check your model serving dashboard
+        - `CONTAINER_IMAGE` – full image path where the agent container will be pushed and pulled from. The image is built
+          locally, pushed to this registry, and then deployed to OpenShift.
+
+          Format: `<registry>/<namespace>/<image-name>:<tag>`
+
+          Examples:
+
+          - Quay.io: `quay.io/your-username/google-adk-agent:latest`
+          - Docker Hub: `docker.io/your-username/google-adk-agent:latest`
+          - GHCR: `ghcr.io/your-org/google-adk-agent:latest`
+
+          > **Note:** OpenShift must be able to pull the container image. Make the image **public**, or configure
+          an [image pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html)
+          for private registries.
+
+        ### Building the Container Image
+
+        Login to OC
+
+        ```bash
+        oc login -u "login" -p "password" https://super-link-to-cluster:111
+        ```
+
+        Login ex. Docker
+
+        ```bash
+        docker login -u='login' -p='password' quay.io
+        ```
+
+        #### Option A: Build locally and push to a registry
+
+        Requires Podman (or Docker) and a registry account (e.g., Quay.io).
+
+        ```bash
+        make build    # builds the image locally
+        make push     # pushes to the registry specified in CONTAINER_IMAGE
+        ```
+
+        #### Option B: Build in-cluster via OpenShift BuildConfig
+
+        No Podman, Docker, or registry account needed — just the `oc` CLI.
+
+        ```bash
+        make build-openshift
+        ```
+
+        After the build completes, set `CONTAINER_IMAGE` in your `.env` to the internal registry URL printed after the build.
+
+        ### Deploying
+
+        #### Preview manifests (`make dry-run`)
+
+        ```bash
+        make dry-run          # preview rendered Helm manifests (secrets redacted)
+        ```
+
+        #### Deploy (`make deploy`)
+
+        ```bash
+        make deploy
+        ```
+
+        #### Verify deployment
+
+        After deploying, the application may take about a minute to become available while the pod starts up.
+
+        The route URL is printed after `make deploy`. You can also retrieve it manually:
+
+        ```bash
+        oc get route google-adk-agent -o jsonpath='{.spec.host}'
+        ```
+
+        #### Remove deployment (`make undeploy`)
+
+        ```bash
+        make undeploy
+        ```
+
+        See [OpenShift Deployment](../../../docs/openshift-deployment.md) for more details.
+
+        ## Tests
+
+        ```bash
+        make test
+        ```
+
+        ### Behavioral Tests
+
+        Behavioral tests validate tool selection, response quality, latency, and reliability
+        over HTTP against the standard `/chat/completions` endpoint. Run from the **repo root**:
+
+        ```bash
+        cd /path/to/agentic-starter-kits
+
+        GOOGLE_ADK_AGENT_URL=https://<agent-route> \
+          uv run --extra test python -m pytest \
+            agents/google/templates/adk/tests/behavioral/ -v
+        ```
+
+        To enable MLflow trace enrichment (for full tool_calls extraction via F1 scoring):
+
+        ```bash
+        GOOGLE_ADK_AGENT_URL=https://<agent-route> \
+        MLFLOW_TRACKING_URI=<uri> \
+        MLFLOW_EXPERIMENT_NAME=<experiment> \
+        MLFLOW_TRACKING_TOKEN=$(oc whoami -t) \
+        MLFLOW_WORKSPACE=<namespace> \
+        MLFLOW_TRACKING_INSECURE_TLS=true \
+          uv run --extra test python -m pytest \
+            agents/google/templates/adk/tests/behavioral/ -v
+        ```
+
+        MLflow tracing is integrated — when `MLFLOW_TRACKING_URI` is set, traces include
+        `[TOOL]` spans for `dummy_web_search` and `[CHAT_MODEL]` spans for LLM calls via LiteLLM.
+
+        ## API Endpoints
+
+        ### POST /chat/completions
+
+        Non-streaming:
+
+        ```bash
+        curl -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "Best server service?"}], "stream": false}'
+        ```
+
+        Streaming:
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "Search for RedHat OpenShift"}], "stream": true}'
+        ```
+
+        Pretty Printed Stream:
+
+        ```bash
+        curl -sN -X POST http://localhost:8000/chat/completions \
+          -H "Content-Type: application/json" \
+          -d '{"messages": [{"role": "user", "content": "Search for RedHat OpenShift"}], "stream": true}' |
+           jq -R -r -j --stream 'scan("^data:(.*)")[] | fromjson.choices[0].delta.content // empty'
+        ```
+
+        ### GET /health
+
+        ```bash
+        curl http://localhost:8000/health
+        ```
+
+        ---
+
+        ## Agent-Specific Documentation
+
+        ### Architecture
+
+        This agent combines three key components:
+
+        1. **Google ADK 2.0 LlmAgent**: Manages the agent loop (reason, call tools, observe, answer)
+        2. **LiteLLM Model Connector**: Routes LLM calls to any OpenAI-compatible API (OGX)
+        3. **InMemoryRunner**: Handles session management and agent execution
+
+        ```text
+        User Input -> ADK LlmAgent -> LiteLLM -> OGX (OpenAI API)
+                         |                           |
+                         v                           v
+                    Tool Calls              LLM Inference
+                         |                           |
+                         v                           v
+                  Tool Results              Model Response
+                         |                           |
+                         +------ Agent Loop ---------+
+                                      |
+                                      v
+                               Final Response
+        ```
+
+        ### Configuration
+
+        **Environment Variables:**
+
+        | Variable          | Description        | Example                                               |
+        |-------------------|--------------------|-------------------------------------------------------|
+        | `BASE_URL`        | LLM API endpoint   | `http://localhost:8321/v1`                            |
+        | `MODEL_ID`        | Model identifier   | `ollama/Llama3.1:8B`                                  |
+        | `API_KEY`         | API authentication | `not-needed-for-local-development` (local) or API key |
+        | `CONTAINER_IMAGE` | Container registry | `quay.io/user/google-adk-agent:latest`                |
+
+        **Customization:**
+
+        Edit `src/adk_agent/tools.py` to add new tools:
+
+        ```python
+        def my_custom_tool(query: str) -> dict:
+            """Description of what this tool does.
+
+            Args:
+                query: The input for the tool.
+
+            Returns:
+                A dict with status and result.
+            """
+            return {"status": "success", "result": "Tool output here"}
+        ```
+
+        Then register it in `src/adk_agent/__init__.py`:
+
+        ```python
+        from .tools import dummy_web_search, my_custom_tool
+
+        TOOLS = [dummy_web_search, my_custom_tool]
+        ```
+
+        ### Troubleshooting
+
+        **Error: "OPENAI_API_BASE not set"**
+
+        - Solution: Ensure `BASE_URL` is set in your `.env` file
+
+        **Tool calls returned as plain text instead of function calls**
+
+        - This can happen with smaller models (e.g., `llama3.2:3b`). Try a larger model or ensure
+          the model supports function calling through OGX.
+
+        **LiteLLM debug mode**
+
+        - To see the actual API requests being made, add to your code:
+
+          ```python
+          import litellm
+          litellm._turn_on_debug()
+          ```
+
+        ### Additional Resources
+
+        - **Google ADK 2.0 Documentation**: <https://google.github.io/adk-docs/2.0/>
+        - **LiteLLM Documentation**: <https://docs.litellm.ai/>
+        - **OGX Documentation**: <https://ogx-ai.github.io/docs/>
+        - **Ollama Documentation**: <https://ollama.com/docs>
+
+        ---
+
+        ## License
+
+        MIT License
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/google/templates/adk
+      framework: google-adk
+      agentType: starter_kit
+      env:
+        - name: API_KEY
+          required: true
+        - name: BASE_URL
+          required: true
+        - name: MODEL_ID
+          required: true
+        - name: PORT
+          required: false
+        - name: CONTAINER_IMAGE
+          required: false
+    - name: langflow-simple-tool-calling-agent
+      displayName: Langflow Simple Tool Calling Agent
+      description: Tool-calling agent built with Langflow's visual flow builder. Calls external APIs as tools and reasons over results.
+      readme: |
+        <div style="text-align: center;">
+
+        # Simple Tool Calling Agent
+
+        </div>
+
+        ---
+
+        ## What this agent does
+
+        Tool-calling agent built with Langflow's visual flow builder. It calls external APIs as tools (weather forecasts,
+        national park data) and reasons over the results to answer user questions. Includes Langfuse v3 tracing out of the box.
+
+        **Example queries:**
+
+        - *"Can I go walking in Boston tomorrow at 3 PM?"*
+        - *"I want to go hiking near Denver this weekend. What day is best?"*
+        - *"Is it a good day for a picnic in San Francisco?"*
+
+        ### Tools
+
+        | Tool                | API        | Description                                            |
+        |---------------------|------------|--------------------------------------------------------|
+        | Open-Meteo Forecast | Open-Meteo | Daily weather forecast (temp, wind, precipitation, UV) |
+        | NPS Search Parks    | NPS API    | Search national parks by state                         |
+        | NPS Park Alerts     | NPS API    | Active alerts and closures for a park                  |
+
+        > **Note:** Unlike other agents in this repo, Langflow agents do not deploy a custom container. The "agent" is a JSON
+        > flow definition imported into an existing Langflow instance. There is no Dockerfile, Helm chart, or FastAPI
+        > application.
+
+        ---
+
+        ## Prerequisites
+
+        - [Podman](https://podman.io/) + [podman-compose](https://github.com/containers/podman-compose) — for running the local
+          stack
+        - [GNU Make](https://www.gnu.org/software/make/) and a bash-compatible shell — on Windows,
+          use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (recommended)
+          or [Git Bash](https://git-scm.com/downloads)
+
+        ### Installing Podman
+
+        **macOS:**
+
+        ```bash
+        brew install podman             # install podman runtime
+        brew install podman-compose     # install compose plugin
+        podman machine init             # create a Linux VM (podman runs containers in a VM on macOS)
+        podman machine start            # start the VM
+        ```
+
+        **Linux:**
+
+        ```bash
+        sudo dnf install -y podman      # install podman runtime
+        uv pip install podman-compose   # install compose plugin
+        sudo systemctl start podman     # start the podman service
+        ```
+
+        ## Local Development
+
+        ### Initiating base
+
+        Here you copy .env.example file into .env and generate Langfuse secrets
+
+        ```bash
+        cd agents/langflow/templates/simple_tool_calling_agent
+        make init
+        ```
+
+        ### Setup Ollama
+
+        This will install ollama if it is not installed already. Then pull needed models for local work.
+        The default model is `qwen2.5:7b`. To use a different model, pass `MODEL=`:
+        `make ollama MODEL=llama3.1:8b`
+
+        ```bash
+        make ollama
+        ```
+
+        ### Run OGX server
+
+        > **Keep this terminal open** – the server needs to keep running.
+        > You should see output indicating the server started on `http://localhost:8321`.
+
+        ```bash
+        make ogx-server
+        ```
+
+        ### Run the Langflow stack
+
+        > **Keep this terminal open** – the stack needs to keep running.
+        > This starts Langflow + PostgreSQL + Langfuse v3 (ClickHouse, MinIO, Redis).
+
+        ```bash
+        make run
+        ```
+
+        > **macOS: If `make run` fails with `statfs ... init-db.sh: operation not permitted`:** your Podman machine may need
+        > rootful mode. This happens on some configurations where the VM cannot bind-mount host files in rootless mode. Run:
+        >
+        > ```bash
+        > podman machine stop
+        > podman machine set --rootful
+        > podman machine start
+        > make run
+        > ```
+        >
+        > Note: rootful mode reduces container isolation. If you want to revert after you're done working with this agent,
+        > run `podman machine set --rootful=false` — but you will need to set rootful mode again before running `make run`.
+
+        ### Import the flow
+
+        1. Open <http://localhost:7860>
+        2. On first launch, Langflow asks you to create a flow — create a **Blank Flow** (this is just to get past the initial
+           screen)
+        3. Click the **Langflow icon** (top left) to go to the projects page
+        4. Click **Upload Flow** and select `flows/outdoor-activity-agent.json`
+
+        ### Configuration
+
+        Configure the flow components:
+
+        | Component        | Field      | Value                                     |
+        |------------------|------------|-------------------------------------------|
+        | KServe vLLM      | api_base   | `http://host.containers.internal:8321/v1`   |
+        | KServe vLLM      | model_name | ollama/qwen2.5:7b                         |
+        | KServe vLLM      | api_key    | not-needed-for-local-development          |
+        | NPS Search Parks | api_key    | Get one free at `https://developer.nps.gov` |
+        | NPS Park Alerts  | api_key    | Same NPS key as above                     |
+
+        ### Pointing to a locally hosted model
+
+        See [Local Development](../../../docs/local-development.md) for Ollama + OGX setup for local model serving.
+
+        **Notes:**
+
+        - `api_base` — use `host.containers.internal` instead of `localhost` so containerized Langflow can reach OGX
+          running on the host
+        - `api_key` — OGX doesn't require authentication, so any non-empty string works
+        - `model_name` — not all models handle tool calling well. `qwen2.5:7b` and `llama3.1:8b` are known to work
+
+        ### Pointing to a remotely hosted model
+
+        Update the **KServe vLLM** component in the Langflow UI:
+
+        | Field      | Value                  |
+        |------------|------------------------|
+        | api_base   | your-model-endpoint/v1 |
+        | model_name | your-model-id          |
+        | api_key    | your-api-key           |
+
+        ### Running the Agent
+
+        Run the agent from the Langflow UI by clicking the **Play** button.
+
+        ### Tracing
+
+        Langfuse v3 tracing is included in the local stack and starts automatically. No additional setup needed.
+
+        - **Langfuse UI**: <http://localhost:3000>
+        - **Login**: `admin@langflow.local` / password auto-generated in `local/.env`
+
+        After running the agent, select the **Langflow Agent** project and click **Traces** to see agent executions — LLM calls,
+        tool invocations, inputs, and outputs.
+
+        ### Stopping the stack
+
+        ```bash
+        make stop        # stop services, keep data
+        make clean       # stop services, remove all data
+        ```
+
+        | Data                                 | `make stop` | `make clean`                   |
+        |--------------------------------------|-------------|--------------------------------|
+        | Imported Langflow flows              | Kept        | **Deleted** (re-import needed) |
+        | Langfuse traces (ClickHouse + MinIO) | Kept        | **Deleted**                    |
+        | PostgreSQL data                      | Kept        | **Deleted**                    |
+        | Redis cache                          | Kept        | **Deleted**                    |
+        | `local/.env` config                  | Kept        | **Deleted**                    |
+
+        ## Deploying to Cluster
+
+        There is nothing to build or deploy — no Dockerfiles, no Helm charts, no k8s manifests. This agent assumes Langflow,
+        Langfuse, and an LLM (OGX/KServe) are already running on the cluster. You just import the flow JSON into the
+        existing Langflow instance and configure it.
+
+        ### Login to OC
+
+        ```bash
+        oc login -u "login" -p "password" https://super-link-to-cluster:111
+        ```
+
+        ### Finding cluster endpoints
+
+        Reach out to your cluster admin for the Langflow URL and OGX endpoint/model names. If you have `oc` CLI access,
+        you can find them yourself:
+
+        ```bash
+        # Langflow UI URL
+        oc get routes --all-namespaces | grep langflow
+
+        # OGX URL
+        oc get routes --all-namespaces | grep ogx
+
+        # KServe model (internal endpoint + model name)
+        oc get inferenceservice --all-namespaces
+        ```
+
+        ### Steps
+
+        1. Open the Langflow UI on your cluster
+        2. Import `flows/outdoor-activity-agent.json`
+        3. Configure the flow components:
+            - **KServe vLLM**: set `api_base` and `model_name`. You can connect through OGX or directly to KServe:
+
+              | Option | api_base | model_name |
+                    |--------|----------|------------|
+              | Via OGX (external route) | `https://<ogx-route-host>/v1` | vllm//mnt/models |
+              | Via OGX (internal) | `http://ogx-service.<namespace>.svc.cluster.local:8321/v1` | vllm//mnt/models |
+              | Direct to KServe (internal) | `http://<model>-predictor.<namespace>.svc.cluster.local:8080/v1` | /mnt/models |
+
+              Use the external route if Langflow can't reach OGX internally (network policy). Use `oc get routes` and
+              `oc get inferenceservice` to find the actual hostnames and namespaces.
+            - **NPS Search Parks**: set `api_key` (get one free at <https://developer.nps.gov>)
+            - **NPS Park Alerts**: set `api_key` (same NPS key)
+        4. Run the agent
+
+        ## API Endpoints
+
+        ### POST /api/v1/run/\<flow-id\>
+
+        ```bash
+        curl -X POST http://localhost:7860/api/v1/run/<flow-id> \
+          -H "Content-Type: application/json" \
+          -d '{"input_value": "What is the best day to hike near Denver?", "output_type": "chat", "input_type": "chat"}'
+        ```
+
+        Replace `<flow-id>` with the flow ID from the Langflow UI. You can find it in the browser URL bar when you open the
+        flow — e.g., `http://localhost:7860/flow/27e7203d-b2b1-4700-962a-144a66155f14` → the flow ID is
+        `27e7203d-b2b1-4700-962a-144a66155f14`.
+
+        On the cluster, replace `localhost:7860` with your cluster's Langflow route URL.
+
+        ## Exporting Flows
+
+        When exporting a flow from Langflow, API keys and secrets can be embedded in the exported JSON file. To avoid leaking
+        secrets:
+
+        1. In the export dialog, **uncheck "Save with API keys"** — this excludes all API keys from the exported file
+        2. If you already exported with keys included, you can strip them manually by searching for `"api_key"` fields in the
+           JSON and clearing their `"value"` entries
+
+        ## Behavioral Tests
+
+        Behavioral tests validate tool selection accuracy, response quality, latency, and reliability against the live agent.
+        Tests are under `tests/behavioral/` and run from the **repo root** (test deps are in the root `pyproject.toml`).
+
+        ```bash
+        cd /path/to/agentic-starter-kits
+
+        # Check tests are discovered (no env vars needed — flow_id validated at runtime)
+        uv run --extra test python -m pytest agents/langflow/templates/simple_tool_calling_agent/tests/behavioral/ --collect-only
+
+        # Run against live agent
+        LANGFLOW_TOOL_CALLING_AGENT_URL=<langflow-url> \
+        LANGFLOW_FLOW_ID=<flow-id> \
+        uv run --extra test python -m pytest agents/langflow/templates/simple_tool_calling_agent/tests/behavioral/ -v
+
+        # Exclude slow reliability tests
+        uv run --extra test python -m pytest agents/langflow/templates/simple_tool_calling_agent/tests/behavioral/ -v -m "not slow"
+        ```
+
+        | Env var | Description |
+        |---------|-------------|
+        | `LANGFLOW_TOOL_CALLING_AGENT_URL` | Langflow instance URL (default: `http://localhost:7860`) |
+        | `LANGFLOW_FLOW_ID` | **Required.** Flow ID — changes on re-import, discover via `GET /api/v1/flows/` |
+
+        **Differences from standard agents:**
+
+        - No MLflow enrichment — tool calls are extracted from Langflow response `content_blocks`
+        - Uses `api_format="langflow_run"` and `flow_id` in TaskConfig (harness adapter from RHAIENG-5389)
+        - No streaming support — always `stream=False`
+        - Lower thresholds than standard agents (smaller model + external API latency)
+
+        ## Resources
+
+        - [Langflow Documentation](https://docs.langflow.org/)
+        - [Open-Meteo](https://open-meteo.com/) — Weather and air quality (free, no key required)
+        - [National Park Service API](https://developer.nps.gov) — Park search and alerts (free key required)
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/langflow/templates/simple_tool_calling_agent
+      framework: langflow
+      agentType: starter_kit
+    - name: a2a-langgraph-crewai
+      displayName: A2A LangGraph ↔ CrewAI
+      description: A2A demo — CrewAI specialist and LangGraph orchestrator (one Dockerfile; two tags / image refs for deploy).
+      readme: |
+        <div style="text-align: center;">
+
+        <img src="/images/a2a-logo-black.svg" alt="A2A (Agent-to-Agent) protocol logo" width="100" height="100">
+
+        # A2A: LangGraph ↔ CrewAI
+
+        *A2A logo from the upstream:* [`A2A project`](https://github.com/a2aproject/A2A/blob/main/docs/assets/a2a-logo-black.svg)
+
+        </div>
+
+        ---
+
+        ## What this agent does
+
+        An **A2A (Agent-to-Agent)** example: a **CrewAI** pod exposes an A2A JSON-RPC server, and a **LangGraph** pod acts as an orchestrator that calls the Crew specialist over HTTP/A2A inside the cluster (or locally). One container image is built from a single `Dockerfile`; **`A2A_ROLE`** in the pod (`crew` vs `langgraph`) selects which process runs.
+
+        ---
+
+        ## Prerequisites
+
+        - [uv](https://docs.astral.sh/uv/) — Python package manager
+        - [Podman](https://podman.io/) or [Docker](https://www.docker.com/) — for local container builds (`Makefile` uses whichever is on `PATH`)
+        - [oc](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html) — for OpenShift deployment
+        - [Helm](https://helm.sh/) — for deploying to Kubernetes/OpenShift
+        - [GNU Make](https://www.gnu.org/software/make/) and a bash-compatible shell — on Windows, use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) (recommended) or [Git Bash](https://git-scm.com/downloads)
+
+        ---
+
+        ## Local Development
+
+        ### Setup
+
+        #### Initiating base
+
+        ```bash
+        cd agents/a2a/templates/langgraph_crewai_agent
+        make init        # creates .env from template.env if missing
+        ```
+
+        Edit `.env` with your configuration (see [Configuration](#configuration) below).
+
+        #### Creating environment
+
+        Install dependencies with `make env`, same idea as the Google ADK agent ([Creating environment](../../google/adk/README.md#creating-environment)):
+
+        ```bash
+        make env
+        ```
+
+        This runs `uv sync --python 3.12` and creates or updates `.venv`.
+
+        ### Configuration
+
+        #### Pointing to a locally hosted model
+
+        You can use placeholders for container images if you only run Python locally:
+
+        ```ini
+        API_KEY=your-key-or-not-needed
+        BASE_URL=http://localhost:8321/v1
+        MODEL_ID=ollama/Llama3.1:8B
+        CONTAINER_IMAGE=not-needed
+        CREW_A2A_PUBLIC_URL=http://127.0.0.1:9100
+        LANGGRAPH_A2A_PUBLIC_URL=http://127.0.0.1:9200
+        CREW_A2A_URL=http://127.0.0.1:9100
+        CREW_A2A_PORT=9100
+        LANGGRAPH_A2A_PORT=9200
+        ```
+
+        See [Local Development](../../../docs/local-development.md) for Ollama + OGX setup for local model serving.
+
+        #### OpenShift cluster (values for `make build` / `make push` / `make deploy`)
+
+        Edit `.env` with your keys and registry image(s):
+
+        ```ini
+        API_KEY=your-api-key-here
+        BASE_URL=https://your-ogx.example.com/v1
+        MODEL_ID=your-model-id
+        CONTAINER_IMAGE=quay.io/your-org/a2a-langgraph-crewai:latest
+        ```
+
+        ### Tracing with a local MLflow server (optional)
+
+        To enable MLflow tracing, add the following to your `.env`:
+
+        ```ini
+        # Disable CrewAI's built-in tracing (we use MLflow instead)
+        CREWAI_TRACING_ENABLED=false
+
+        MLFLOW_TRACKING_URI="http://localhost:5000"
+        MLFLOW_EXPERIMENT_NAME="a2a-langgraph-crewai"
+        MLFLOW_HTTP_REQUEST_TIMEOUT=2
+        MLFLOW_HTTP_REQUEST_MAX_RETRIES=0
+        ```
+
+        **Important:** `CREWAI_TRACING_ENABLED=false` disables CrewAI's built-in telemetry system, which can interfere with execution and block the crew from running. We use MLflow for tracing instead.
+
+        Then start the MLflow server in a separate terminal:
+
+        ```bash
+        # Start the MLflow server
+        uv run --extra tracing mlflow server --port 5000
+        ```
+
+        When `MLFLOW_TRACKING_URI` is set, `make run-app`, `make run-crew`, and `make run-langgraph` will automatically install the tracing dependency.
+
+        #### Configuring the LLM provider for tracing (CrewAI only)
+
+        The CrewAI server can use different LLM providers. Set `LLM_PROVIDER` to match your provider so MLflow uses the correct autolog integration:
+
+        | `LLM_PROVIDER` value | MLflow autolog enabled       | When to use                 |
+        |----------------------|------------------------------|-----------------------------|
+        | `litellm` (default)  | `mlflow.litellm.autolog()`   | OpenAI-compatible endpoints |
+        | `openai`             | `mlflow.openai.autolog()`    | Direct OpenAI API           |
+        | `anthropic`          | `mlflow.anthropic.autolog()` | Anthropic API               |
+        | `gemini`             | `mlflow.gemini.autolog()`    | Google Gemini API           |
+        | `azure`              | `mlflow.openai.autolog()`    | Azure OpenAI                |
+        | `bedrock`            | `mlflow.bedrock.autolog()`   | AWS Bedrock                 |
+
+        **Note:** The LangGraph server uses `mlflow.langchain.autolog()` which automatically traces LangChain components regardless of the underlying LLM provider, so `LLM_PROVIDER` only affects the CrewAI server.
+
+        ### Tracing with an OpenShift MLflow server (optional)
+
+        To enable tracing and logging with MLflow on your OpenShift cluster, add the following environment variables to your `.env` file:
+
+        ```ini
+        # Disable CrewAI's built-in tracing (we use MLflow instead)
+        CREWAI_TRACING_ENABLED=false
+
+        MLFLOW_TRACKING_URI="https://<openshift-dashboard-url>/mlflow"
+        MLFLOW_TRACKING_TOKEN="<your-openshift-token>"
+        MLFLOW_EXPERIMENT_NAME="a2a-langgraph-crewai"
+        MLFLOW_TRACKING_INSECURE_TLS="true"  # ⚠️ Development only - use proper certificates in production
+        MLFLOW_WORKSPACE="default"
+        ```
+
+        **Notes:**
+
+        - `MLFLOW_TRACKING_URI` - Replace `<openshift-dashboard-url>` with your OpenShift cluster's data science gateway URL
+        - `MLFLOW_TRACKING_TOKEN` - Your openshift authentication token. It can be obtained from the openshift console.
+        - `MLFLOW_EXPERIMENT_NAME` - A descriptive name for your experiment (e.g., "A2A LangGraph CrewAI Demo")
+        - `MLFLOW_TRACKING_INSECURE_TLS` - **Development only** - disables certificate verification. Never use in production. Deploy proper TLS certificates instead.
+        - `MLFLOW_WORKSPACE` - Project name
+        - `LLM_PROVIDER` - (CrewAI only) Which provider autolog to use (default: `litellm`)
+
+        - Tracing is optional; if you do not set `MLFLOW_TRACKING_URI`, the application will run without MLflow logging.
+        - If `MLFLOW_TRACKING_URI` is set, the application will attempt to connect to the MLflow server at startup. If the server is unreachable, the application will log a warning and continue running without tracing.
+        - Both servers (CrewAI and LangGraph) will emit traces to the same MLflow experiment when tracing is enabled.
+
+        #### Differentiating traces from each server
+
+        By default, both servers emit traces to the same experiment. You can differentiate traces using:
+
+        **1. Span names (automatic)** - Each framework produces distinct span names:
+
+        - LangGraph traces: `LangGraph`, `ChatOpenAI`, `ask_crew_specialist`
+        - CrewAI traces: `CrewAI`, `Task`, `Agent`, `Web Search`
+
+        **2. Separate experiments (optional)** - Use different experiments for each server:
+
+        ```ini
+        # Separate experiments
+        MLFLOW_EXPERIMENT_NAME_LANGGRAPH="a2a-langgraph-traces"
+        MLFLOW_EXPERIMENT_NAME_CREWAI="a2a-crewai-traces"
+
+        # Shared experiment (default if above not set)
+        MLFLOW_EXPERIMENT_NAME="a2a-langgraph-crewai"
+        ```
+
+        If `MLFLOW_EXPERIMENT_NAME_LANGGRAPH` or `MLFLOW_EXPERIMENT_NAME_CREWAI` are set, they take priority over `MLFLOW_EXPERIMENT_NAME` for their respective servers.
+
+        ### Running the agent
+
+        Install dependencies and configure `.env`, then either use **Make** (same idea as the Google ADK agent) or run the two Python modules by hand.
+
+        **Option A — one terminal (`make run-app`)**
+
+        ```bash
+        make init         # .env from template.env if needed — then edit .env
+        make env          # uv sync into .venv (once)
+        make run-app      # Crew in background, LangGraph in foreground (Ctrl+C stops both)
+        ```
+
+        If ports **9100** / **9200** are stuck: `make run-app-fresh`.
+
+        **Option B — two terminals (`uv run`)**
+
+        ```bash
+        uv sync
+        set -a && source .env && set +a
+        ```
+
+        ```bash
+        # Terminal 1 — CrewAI + A2A
+        uv run python -m a2a_langgraph_crewai.crew_a2a_server
+
+        # Terminal 2 — LangGraph orchestrator
+        uv run python -m a2a_langgraph_crewai.langgraph_a2a_server
+        ```
+
+        Single-process shortcuts: `make run-crew` or `make run-langgraph`.
+
+        Default ports: **9100** (Crew), **9200** (LangGraph). Do not set `PORT` unless you mirror the container (`8080`).
+
+        ### Playground (LangGraph orchestrator)
+
+        With the LangGraph server running (terminal 2), open **<http://127.0.0.1:9200/>** in a browser. The chat uses **A2A JSON-RPC** on **`POST /`** with **`message/send`**. The server also exposes **`POST /chat/completions`** (OpenAI-style). For local `curl`, use `http://127.0.0.1:9200`.
+
+        ---
+
+        ## Deploying to OpenShift
+
+        Uses **[Helm](https://helm.sh/)** + **`Makefile`**. Chart: **`agents/a2a/deployment/`** (two Deployments, two Services, two Routes, one Secret).
+
+        ### Setup
+
+        ```bash
+        cd agents/a2a/templates/langgraph_crewai_agent
+        make init
+        ```
+
+        ### Configuration
+
+        Edit `.env` with your model endpoint and container image(s).
+
+        **Option A — one registry path; `make build` / `make push` produce `:crew` and `:langgraph` from the same stem:**
+
+        ```ini
+        API_KEY=your-api-key-here
+        BASE_URL=https://your-model-endpoint.com/v1
+        MODEL_ID=your-model-id
+        CONTAINER_IMAGE=quay.io/your-username/a2a-langgraph-crewai:latest
+        ```
+
+        **Option B — two full image refs (e.g. separate repos or explicit tags):**
+
+        ```ini
+        API_KEY=your-api-key-here
+        BASE_URL=https://your-model-endpoint.com/v1
+        MODEL_ID=your-model-id
+        CONTAINER_IMAGE_CREW=quay.io/your-username/a2a-crewai:latest
+        CONTAINER_IMAGE_LANGGRAPH=quay.io/your-username/a2a-langgraph:latest
+        ```
+
+        **Notes:**
+
+        - `API_KEY` — your API key or contact your cluster administrator
+        - `BASE_URL` — should end with `/v1`
+        - `MODEL_ID` — model identifier available on your endpoint
+        - **`CONTAINER_IMAGE_CREW`** and **`CONTAINER_IMAGE_LANGGRAPH`** instead.
+
+          Examples (stem style): Quay.io `quay.io/your-username/a2a-langgraph-crewai:latest`, Docker Hub, GHCR — same pattern as `template.env`.
+
+          > **Note:** OpenShift must be able to pull **both** image refs. Make them **public**, or configure an [image pull secret](https://docs.openshift.com/container-platform/latest/openshift_images/managing_images/using-image-pull-secrets.html) for private registries.
+
+        ### Building the container image
+
+        Log in to the cluster and registry:
+
+        ```bash
+        oc login --token=<token> --server=https://<cluster-api-url>
+        oc project <namespace>
+        docker login -u='login' -p='password' quay.io
+        ```
+
+        #### Option A: Build locally and push to a registry
+
+        Requires Podman or Docker (with `buildx` where needed) and a registry account (e.g. Quay.io).
+
+        `make build` loads the image locally and tags **`:crew`** and **`:langgraph`** (one build, second ref via `tag`). `make push` uploads both refs to the registry.
+
+        ```bash
+        make build    # build once, tag :crew and :langgraph locally
+        make push     # push both tags to the registry
+        ```
+
+        Run **`make build && make push`** after image or `Dockerfile` changes, then **`make deploy`**.
+
+        ### Deploying
+
+        #### Preview manifests (`make dry-run`)
+
+        ```bash
+        make dry-run          # preview rendered Helm manifests (secrets redacted)
+        ```
+
+        #### Deploy (`make deploy`)
+
+        ```bash
+        make deploy
+        ```
+
+        The LangGraph pod uses in-cluster **`CREW_A2A_URL=http://a2a-crew-agent:8080`**.
+
+        #### Manage Agents using Kagenti (Optional)
+
+        Register agents with [Kagenti](https://github.com/kagenti/kagenti) for unified discovery and management.
+
+        **Prerequisites:**
+
+        - Kagenti installed: `oc get pods -n kagenti-system`
+        - Namespace labeled: `oc label namespace <your-namespace> kagenti-enabled=true`
+
+        **Apply AgentRuntime:**
+
+        NOTE: The `AgentRuntime.yaml` file will be applied
+        Apply:
+
+           ```bash
+           oc apply -f AgentRuntime.yaml
+           ```
+
+        **Verify:**
+
+        ```bash
+        oc get agentcard -n <your-namespace>
+        ```
+
+        AgentCards for both LangGraph and CrewAI will appear in Kagenti UI.
+
+        #### Verify deployment
+
+        After deploying, the application may take about a minute to become available while the pods start.
+
+        Route hosts are printed after `make deploy`. Retrieve them manually:
+
+        ```bash
+        oc get route a2a-langgraph-agent -o jsonpath='{.spec.host}'
+        ```
+
+        #### Remove deployment (`make undeploy`)
+
+        ```bash
+        make undeploy
+        ```
+
+        See [OpenShift Deployment](../../../docs/openshift-deployment.md) for more details.
+
+        ---
+
+        ## API Endpoints (LangGraph route)
+
+        **Use the LangGraph orchestrator for every `curl` below** — Route **`a2a-langgraph-agent`** on OpenShift, or **`http://127.0.0.1:9200`** locally. That is the public entrypoint (playground, Agent Card, `/health`, A2A JSON-RPC, `/chat/completions`).
+
+        Do **not** aim `curl` at the Crew specialist (`a2a-crew-agent` / port **9100**): Crew is the peer the LangGraph pod calls over A2A in-cluster; clients should talk to **LangGraph** so the orchestrator can delegate when needed.
+
+        On OpenShift, routes terminate TLS at the edge; use **`https://`**. Replace **`<YOUR_ROUTE_URL>`** with the **LangGraph** route host, e.g.:
+
+        ```bash
+        oc get route a2a-langgraph-agent -o jsonpath='{.spec.host}'
+        ```
+
+        ### GET `/.well-known/agent-card.json`
+
+        ```bash
+        curl -sS "https://<YOUR_ROUTE_URL>/.well-known/agent-card.json"
+        ```
+
+        ### GET `/health`
+
+        ```bash
+        curl -sS "http://127.0.0.1:9200/health"
+        ```
+
+        ```bash
+        curl -sS "https://<YOUR_ROUTE_URL>/health"
+        ```
+
+        ### POST `/` — A2A JSON-RPC (`message/send`)
+
+        Same protocol as the browser playground: JSON-RPC 2.0 body = `SendMessageRequest` (see [a2a-sdk](https://pypi.org/project/a2a-sdk/)). Use a unique `messageId` per request.
+
+        ```bash
+        curl -sS -X POST "https://<YOUR_ROUTE_URL>/" \
+          -H "Content-Type: application/json" \
+          -H "Accept: application/json" \
+          -d '{"jsonrpc":"2.0","method":"message/send","params":{"message":{"role":"user","parts":[{"kind":"text","text":"Use the web search tool to find the Red Hat encrypted string."}],"messageId":"0123456789abcdef0123456789abcdef"}},"id":"curl-req-1"}'
+        ```
+
+        The response is JSON-RPC (`result` or `error`), not OpenAI chat format.
+
+        ### POST `/chat/completions`
+
+        Non-streaming:
+
+        ```bash
+        curl -sS -X POST "https://<YOUR_ROUTE_URL>/chat/completions" \
+          -H "Content-Type: application/json" \
+          -d '{"messages":[{"role":"user","content":"Use the web search tool to find the Red Hat encrypted string."}],"stream":false}'
+        ```
+
+        Streaming (SSE; use `-N` / `--no-buffer` so chunks print as they arrive):
+
+        ```bash
+        curl -sS -N -X POST "https://<YOUR_ROUTE_URL>/chat/completions" \
+          -H "Content-Type: application/json" \
+          -H "Accept: text/event-stream" \
+          -d '{"messages":[{"role":"user","content":"Use the web search tool to find the Red Hat encrypted string."}],"stream":true}'
+        ```
+
+        For local runs, use `http://127.0.0.1:9200` instead of `https://<YOUR_ROUTE_URL>`. The stream may include leading `a2a.protocol` trace events before `chat.completion.chunk` lines.
+
+        ---
+
+        ## Agent-specific documentation
+
+        ### Architecture (OpenShift)
+
+        | Resource | Role |
+        |----------|------|
+        | Helm chart **`agents/a2a/deployment`** | Secret, Services, Routes, Deployments |
+        | `Deployment` **a2a-crew-agent** | CrewAI + A2A server, port **8080** |
+        | `Deployment` **a2a-langgraph-agent** | LangGraph + tool → `CREW_A2A_URL` |
+        | `Service` + `Route` ×2 | HTTPS; hosts feed Agent Card URLs |
+        | In-cluster | `CREW_A2A_URL=http://a2a-crew-agent:8080` |
+
+        ## Resources
+
+        - [A2A Python SDK](https://pypi.org/project/a2a-sdk/)
+        - [Deploying to OpenShift (generic)](../../../docs/openshift-deployment.md)
+        - [Local Development](../../../docs/local-development.md)
+        - Related patterns: `agents/google/templates/adk/` (Helm + `make build` / `make push` / `make deploy`), `agents/llamaindex/templates/websearch_agent/`, `agents/langgraph/templates/react_agent/`
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/a2a/templates/langgraph_crewai_agent
+      framework: a2a
+      agentType: starter_kit
+      env:
+        - name: API_KEY
+          required: true
+        - name: BASE_URL
+          required: true
+        - name: MODEL_ID
+          required: true
+        - name: CONTAINER_IMAGE
+          required: false
+        - name: CONTAINER_IMAGE_CREW
+          required: false
+        - name: CONTAINER_IMAGE_LANGGRAPH
+          required: false
+    - name: claude-code
+      displayName: Claude Code on OpenShift
+      description: Deploy Claude Code on OpenShift with multiple backend options (Anthropic API, Vertex AI, vLLM, OGX).
+      readme: |
+        # Claude Code on OpenShift
+
+        A guide to deploying Claude Code as a containerized agent on Red Hat OpenShift. Supports four backend configurations: Anthropic API, Google Vertex AI, vLLM direct, and vLLM via OGX gateway.
+
+        ## Table of Contents
+
+        - [Licensing Notice](#licensing-notice)
+        - [Prerequisites](#prerequisites)
+        - [Step 1: Build the Container Image](#step-1-build-the-container-image)
+        - [Step 2: Create an OpenShift Project](#step-2-create-an-openshift-project)
+        - [Step 3: Choose Your Backend](#step-3-choose-your-backend)
+          - [Option A: Anthropic API](#option-a-anthropic-api)
+          - [Option B: Vertex AI](#option-b-vertex-ai)
+          - [Option C: vLLM Direct](#option-c-vllm-direct)
+          - [Option D: vLLM via OGX Gateway](#option-d-vllm-via-ogx-gateway)
+        - [Using Claude Code](#using-claude-code)
+        - [Configuration](#configuration)
+        - [MLflow Tracing (Optional)](#mlflow-tracing-optional)
+        - [Security Considerations](#security-considerations)
+        - [Troubleshooting](#troubleshooting)
+        - [Cleanup](#cleanup)
+        - [Known Limitations](#known-limitations)
+
+        ---
+
+        ## Licensing Notice
+
+        **Do not redistribute built container images.** The Containerfile installs Claude Code at build time via Anthropic's native installer. The resulting image contains Anthropic's proprietary binary, which is subject to their [commercial terms](https://code.claude.com/docs/en/legal-and-compliance) ("All rights reserved"). Building the image yourself for internal use is permitted, but redistributing the built image (e.g., pushing to a public registry) is not authorized.
+
+        ---
+
+        ## Prerequisites
+
+        - `podman` installed locally (on macOS, also run `podman machine init` and `podman machine start`)
+        - `oc` CLI installed and logged into your OpenShift cluster
+        - An Anthropic API key, a GCP service account key for Vertex AI, or a vLLM/OGX endpoint (no Anthropic credentials needed for self-hosted models)
+
+        All shell commands in this guide assume you are in the `deployment/` subdirectory, where the Containerfile and deployment manifests live:
+
+        ```bash
+        cd deployment/
+        ```
+
+        ---
+
+        ## Step 1: Build the Container Image
+
+        ```bash
+        podman build -t claude-code:latest -f Containerfile .
+
+        # Build with a specific version
+        podman build --build-arg CLAUDE_CODE_VERSION=2.1.123 -t claude-code:2.1.123 -f Containerfile .
+        ```
+
+        To verify the build locally, see the local test command in your chosen backend option below.
+
+        ---
+
+        ## Step 2: Create an OpenShift Project
+
+        ```bash
+        oc new-project my-claude-project
+        ```
+
+        ---
+
+        ## Step 3: Choose Your Backend
+
+        Follow **one** option below, then continue to [Using Claude Code](#using-claude-code).
+
+        | Option | Backend | Manifest | Deployment Name |
+        |--------|---------|----------|-----------------|
+        | [A](#option-a-anthropic-api) | Anthropic API | `deployment.yaml` | `claude-code` |
+        | [B](#option-b-vertex-ai) | Google Vertex AI | `deployment-vertex.yaml` | `claude-code-vertex` |
+        | [C](#option-c-vllm-direct) | vLLM Direct | `deployment-vllm.yaml` | `claude-code-vllm` |
+        | [D](#option-d-vllm-via-ogx-gateway) | vLLM via OGX | `deployment-ogx-vllm.yaml` | `claude-code-ogx-vllm` |
+
+        ---
+
+        ### Option A: Anthropic API
+
+        #### Get your API key
+
+        1. Go to [console.anthropic.com](https://console.anthropic.com/)
+        2. Sign in or create an account
+        3. Navigate to **API Keys** and click **Create Key**
+        4. Copy the key (starts with `sk-ant-api03-...`)
+
+        You need a paid account with credits.
+
+        #### Local test (optional)
+
+        ```bash
+        podman run --rm \
+          -e ANTHROPIC_API_KEY="sk-ant-api03-YOUR_KEY_HERE" \
+          claude-code:latest \
+          claude -p "What is 2+2?"
+        ```
+
+        #### Deploy
+
+        ```bash
+        # Create secret
+        oc create secret generic claude-credentials \
+          --from-literal=ANTHROPIC_API_KEY="sk-ant-api03-YOUR_KEY_HERE"
+
+        # Apply manifest and build
+        oc apply -f deployment.yaml
+        oc start-build claude-code --from-dir=. --follow
+
+        # Wait and test
+        oc rollout status deployment/claude-code
+        oc exec deployment/claude-code -- bash -c '
+          ~/.claude/claude-run -p "What is 2+2?"
+        '
+        ```
+
+        ---
+
+        ### Option B: Vertex AI
+
+        #### Get your GCP credentials
+
+        You need a GCP service account with Vertex AI access.
+
+        **Option 1: GCP Console**
+
+        1. Go to [GCP Console](https://console.cloud.google.com)
+        2. Select your project (Vertex AI API must be enabled)
+        3. Navigate to **IAM & Admin > Service Accounts**
+        4. Click **+ CREATE SERVICE ACCOUNT**
+           - Name: `claude-code-user`
+           - Grant role: **Vertex AI User** (`roles/aiplatform.user`)
+        5. Click the service account > **Keys** tab
+        6. Click **Add Key > Create new key > JSON**
+        7. Save the downloaded key file
+
+        Creating service accounts requires **IAM Admin** or **Service Account Admin** permissions.
+
+        **Option 2: gcloud CLI**
+
+        ```bash
+        gcloud iam service-accounts create claude-code-user \
+          --display-name="Claude Code User"
+
+        gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
+          --member="serviceAccount:claude-code-user@YOUR_PROJECT_ID.iam.gserviceaccount.com" \
+          --role="roles/aiplatform.user"
+
+        gcloud iam service-accounts keys create ~/claude-vertex-key.json \
+          --iam-account=claude-code-user@YOUR_PROJECT_ID.iam.gserviceaccount.com
+        ```
+
+        **Alternative: Application Default Credentials (ADC)**
+
+        If you already have credentials via `gcloud auth application-default login`, you can use your ADC file (typically at `~/.config/gcloud/application_default_credentials.json`) in place of a service account key. ADC credentials are user-scoped and typically carry broader permissions. Use ADC for local development only; for shared clusters, create a dedicated service account.
+
+        #### Local test (optional)
+
+        ```bash
+        podman run --rm \
+          -e CLAUDE_CODE_USE_VERTEX=1 \
+          -e ANTHROPIC_VERTEX_PROJECT_ID="your-gcp-project-id" \
+          -e CLOUD_ML_REGION="global" \
+          -e GOOGLE_APPLICATION_CREDENTIALS="/var/secrets/google/key.json" \
+          -v /path/to/your-service-account-key.json:/var/secrets/google/key.json:ro,z \
+          claude-code:latest \
+          claude -p "What is 2+2?"
+        ```
+
+        #### Deploy
+
+        ```bash
+        # Create secret
+        oc create secret generic claude-vertex-credentials \
+          --from-file=key.json=/path/to/your-service-account-key.json
+
+        # Apply manifest
+        oc apply -f deployment-vertex.yaml
+
+        # Patch ConfigMap with your project details
+        oc patch configmap claude-vertex-config \
+          -p '{"data":{"ANTHROPIC_VERTEX_PROJECT_ID":"your-gcp-project-id","CLOUD_ML_REGION":"global"}}'
+
+        # Build and deploy
+        oc start-build claude-code --from-dir=. --follow
+        oc rollout restart deployment/claude-code-vertex
+        oc rollout status deployment/claude-code-vertex
+
+        # Test
+        oc exec deployment/claude-code-vertex -- bash -c '
+          ~/.claude/claude-run -p "What is 2+2?"
+        '
+        ```
+
+        **Model selection:** On Vertex AI, the default `sonnet` model alias may resolve to an older model than on the direct Anthropic API. To use a specific version:
+
+        ```bash
+        oc set env deployment/claude-code-vertex CLAUDE_MODEL=claude-sonnet-4-6
+        ```
+
+        ---
+
+        ### Option C: vLLM Direct
+
+        Connects Claude Code directly to a vLLM server's `/v1/messages` endpoint.
+
+        ```text
+        Claude Code pod  ──HTTP──>  vLLM server (/v1/messages)
+        ```
+
+        #### Prerequisites
+
+        - A vLLM server with `/v1/messages` endpoint support. If you need to deploy one, see [vllm/README.md](vllm/README.md).
+        - **Context window**: minimum 32K tokens (Claude Code's system prompt is ~23K). For realistic coding work, **128K+ is strongly recommended** since CLAUDE.md, skills, file listings, and conversation easily push past 100K tokens.
+        - Network connectivity from your OpenShift cluster to the vLLM server. See [Network Connectivity](#network-connectivity-vllmogx) in Troubleshooting if the server is outside the cluster.
+
+        **Model quality note:** Claude Code is designed for Anthropic's Claude models. Open source models may produce lower quality results, particularly for complex multi-step tasks. Including language runtimes in the container (see [Extending the Container Image](#extending-the-container-image)) helps because the agent can run tests and catch its own mistakes.
+
+        #### Edit the deployment manifest
+
+        Edit `deployment-vllm.yaml`. Search for placeholder values and replace them:
+
+        - `ANTHROPIC_BASE_URL`: Your vLLM server's base URL, for example:
+          - `http://my-vllm-service.namespace.svc.cluster.local` (cluster-internal)
+          - `https://vllm.apps.cluster.example.com` (external route)
+
+        Replace model IDs in the **ConfigMap** and the **Deployment** env vars. If your vLLM server hosts only one model, use the same model ID everywhere. If it hosts multiple models, you can assign different models to each role (e.g., a small fast model for haiku, a mid-range model for sonnet, and your most capable model for opus).
+
+        | Variable | Purpose | Example (single model) |
+        |----------|---------|----------------------|
+        | ConfigMap `"model"` | Default model in `settings.json` | `gpt-oss-120b` |
+        | `CLAUDE_MODEL` | Main conversation model (overrides ConfigMap) | `gpt-oss-120b` |
+        | `ANTHROPIC_CUSTOM_MODEL_OPTION` | Adds model to the interactive mode picker menu | `gpt-oss-120b` |
+        | `ANTHROPIC_DEFAULT_HAIKU_MODEL` | What the `haiku` alias resolves to (used for background tasks like summarization) | `gpt-oss-120b` |
+        | `ANTHROPIC_DEFAULT_SONNET_MODEL` | What the `sonnet` alias resolves to (selectable via `/model sonnet`) | `gpt-oss-120b` |
+        | `ANTHROPIC_DEFAULT_OPUS_MODEL` | What the `opus` alias resolves to (selectable via `/model opus`, used for plan mode) | `gpt-oss-120b` |
+
+        The three alias overrides are required. Without them, Claude Code tries to resolve haiku, sonnet, and opus to Anthropic model names (e.g., `claude-haiku-4-5-20251001`), which don't exist on vLLM, causing 404 errors.
+
+        #### Context window configuration
+
+        Claude Code defaults to a 180K context window, which causes failures on models with smaller windows. Configure these env vars in the deployment manifest:
+
+        - `CLAUDE_CODE_AUTO_COMPACT_WINDOW`: Your model's context window in tokens (e.g., `131072`). Do not pre-subtract output tokens.
+        - `CLAUDE_CODE_MAX_OUTPUT_TOKENS`: Output budget (e.g., `28000`).
+        - `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`: Autocompaction threshold. Formula: `percentage <= (context_window - max_output_tokens) / context_window * 100`
+
+        | Model | Context | AUTO_COMPACT_WINDOW | MAX_OUTPUT_TOKENS | AUTOCOMPACT_PCT |
+        |-------|---------|--------------------|--------------------|-----------------|
+        | *(32K minimum example)* | 32K | 32768 | 4000 | 85 |
+        | RedHatAI/Qwen3.6-35B-A3B-NVFP4 | 131K | 131072 | 28000 | 75 |
+        | Qwen/Qwen3-235B-A22B | 131K | 131072 | 28000 | 75 |
+        | openai/gpt-oss-120b | 131K | 131072 | 28000 | 75 |
+        | ibm-granite/granite-4.1-8b-instruct | 524K | 524288 | 64000 | 83 |
+        | meta-llama/Llama-4-Maverick-17B-128E | 1,048K | 1048576 | 64000 | 83 |
+
+        Models with 500K+ context can use the default 83% threshold. Models with smaller context windows need a lower percentage to leave sufficient headroom for output tokens. A 32K model is the minimum supported; expect frequent autocompaction and limited conversation depth at this size.
+
+        #### Local test (optional)
+
+        ```bash
+        podman run --rm \
+          -e ANTHROPIC_BASE_URL="https://YOUR_VLLM_ENDPOINT" \
+          -e ANTHROPIC_AUTH_TOKEN="fake" \
+          claude-code:latest \
+          claude --model YOUR_MODEL_ID -p "What is 2+2?"
+        ```
+
+        #### Deploy
+
+        ```bash
+        oc apply -f deployment-vllm.yaml
+        oc start-build claude-code --from-dir=. --follow
+        oc rollout status deployment/claude-code-vllm
+
+        oc exec deployment/claude-code-vllm -- bash -c '
+          ~/.claude/claude-run -p "What is 2+2?"
+        '
+        ```
+
+        ---
+
+        ### Option D: vLLM via OGX Gateway
+
+        Uses OGX (from RHOAI) as an API gateway between Claude Code and vLLM.
+
+        ```text
+        Claude Code pod  ──HTTP──>  OGX (API Gateway)  ──HTTP──>  vLLM server
+        ```
+
+        #### Prerequisites
+
+        - OGX deployed and serving `GET /v1/health`, `GET /v1/models`, and `POST /v1/messages`. See [`ogx/README.md`](ogx/README.md) for one standalone deployment pattern, or reuse an existing OGX endpoint in your cluster.
+        - A vLLM server accessible from OGX.
+        - **Context window**: minimum 32K tokens. **128K+ strongly recommended** for realistic coding work.
+
+        **Model quality note:** Claude Code is designed for Anthropic's Claude models. Open source models may produce lower quality results, particularly for complex multi-step tasks. Including language runtimes in the container (see [Extending the Container Image](#extending-the-container-image)) helps because the agent can run tests and catch its own mistakes.
+
+        #### Edit the deployment manifest
+
+        Edit `deployment-ogx-vllm.yaml`. Search for placeholder values and replace them:
+
+        - `ANTHROPIC_BASE_URL`: Your OGX route URL (replace `YOUR_OGX_URL`)
+
+        Replace model IDs in the **ConfigMap** and the **Deployment** env vars. OGX uses the `vllm/` prefix to route requests to the vLLM backend, so all model IDs must use the exact `vllm/<model-id>` value returned by `GET /v1/models`. If OGX serves only one model, use the same value everywhere. If it serves multiple models, you can assign different models to each role.
+
+        | Variable | Purpose | Example (single model) |
+        |----------|---------|----------------------|
+        | ConfigMap `"model"` | Default model in `settings.json` | `vllm/gpt-oss-120b` |
+        | `CLAUDE_MODEL` | Main conversation model (overrides ConfigMap) | `vllm/gpt-oss-120b` |
+        | `ANTHROPIC_CUSTOM_MODEL_OPTION` | Adds model to the interactive mode picker menu | `vllm/gpt-oss-120b` |
+        | `ANTHROPIC_DEFAULT_HAIKU_MODEL` | What the `haiku` alias resolves to (used for background tasks like summarization) | `vllm/gpt-oss-120b` |
+        | `ANTHROPIC_DEFAULT_SONNET_MODEL` | What the `sonnet` alias resolves to (selectable via `/model sonnet`) | `vllm/gpt-oss-120b` |
+        | `ANTHROPIC_DEFAULT_OPUS_MODEL` | What the `opus` alias resolves to (selectable via `/model opus`, used for plan mode) | `vllm/gpt-oss-120b` |
+
+        The three alias overrides are required. Without them, Claude Code tries to resolve haiku, sonnet, and opus to Anthropic model names, causing 404 errors.
+
+        #### Deploy
+
+        ```bash
+        oc apply -f deployment-ogx-vllm.yaml
+        oc start-build claude-code --from-dir=. --follow
+        oc rollout status deployment/claude-code-ogx-vllm
+
+        oc exec deployment/claude-code-ogx-vllm -- bash -c '
+          ~/.claude/claude-run -p "What is 2+2?"
+        '
+        ```
+
+        ---
+
+        ## Using Claude Code
+
+        The examples below use `claude-code` as the deployment name. Substitute the name from the [backend table](#step-3-choose-your-backend) if you chose a different option.
+
+        ### Running Prompts
+
+        The `claude-run` wrapper includes all container-configured arguments (permission bypass, MCP config, model selection):
+
+        ```bash
+        oc exec deployment/claude-code -- bash -c '
+          ~/.claude/claude-run -p "Your prompt here"
+        '
+        ```
+
+        You can also source the environment directly:
+
+        ```bash
+        oc exec deployment/claude-code -- bash -c '
+          source ~/.claude/env.sh
+          claude $CLAUDE_EXTRA_ARGS -p "Your prompt here"
+        '
+        ```
+
+        ### Interactive Mode
+
+        For multi-turn conversations with a TTY:
+
+        ```bash
+        # OpenShift
+        oc exec -it deployment/claude-code -- bash -c '
+          ~/.claude/claude-run
+        '
+
+        # Local (example with Anthropic API; substitute env vars for your backend)
+        podman run -it --rm \
+          -e ANTHROPIC_API_KEY="sk-ant-api03-YOUR_KEY_HERE" \
+          -v $(pwd):/workspace:z \
+          claude-code:latest \
+          claude
+        ```
+
+        Interactive mode requires the `-it` flags for both `podman` and `oc exec`.
+
+        ### Debug Mode
+
+        ```bash
+        # Full debug logging
+        oc exec -it deployment/claude-code -- bash -c 'claude --debug'
+
+        # API calls only
+        oc exec -it deployment/claude-code -- bash -c 'claude --debug api'
+        ```
+
+        Debug logs are written to a file. To tail them in real time from a second terminal:
+
+        ```bash
+        oc exec deployment/claude-code -- bash -c 'tail -f /home/claude-agent/.claude/debug/*.txt'
+        ```
+
+        ### Retrieving Files from the Container
+
+        When Claude Code generates files (reports, documents, code) that you want locally without pushing to Git, use `oc cp`:
+
+        ```bash
+        # Copy a single file
+        oc cp <pod-name>:/workspace/projects/report.md ./report.md
+
+        # Copy a directory
+        oc cp <pod-name>:/workspace/projects/output/ ./output/
+
+        # Find the pod name
+        oc get pods -l app=claude-code -o name
+
+        # List files in the container
+        oc exec deployment/claude-code -- ls -la /workspace/projects/
+        ```
+
+        ### Rebuilding the Image
+
+        After modifying the Containerfile or entrypoint, rebuild and update the deployment:
+
+        ```bash
+        # Build and push the new image
+        oc start-build claude-code --from-dir=. --follow
+
+        # Update the deployment to use the new image
+        oc set image deployment/<your-deployment-name> \
+          claude-code=$(oc get istag claude-code:latest -o jsonpath='{.image.dockerImageReference}')
+        ```
+
+        `oc rollout restart` alone is not sufficient. OpenShift pins deployments to a specific image digest, so restarting just recreates the pod with the old image. You must update the image reference with `oc set image` to pick up the new build.
+
+        ---
+
+        ## Configuration
+
+        ### Session Persistence
+
+        Session history and memory persist across pod restarts via the workspace PVC. The `CLAUDE_CONFIG_DIR` environment variable points to `/workspace/.claude/`.
+
+        **Directory structure:**
+
+        ```text
+        /workspace/                      <- PVC mount (persistent)
+        |-- .claude/                     <- Global config (CLAUDE_CONFIG_DIR)
+        |   |-- settings.json            <- Copied from ConfigMap at startup
+        |   |-- skills/                  <- ConfigMap mount
+        |   |-- memory/                  <- Persisted (global memory)
+        |   +-- projects/                <- Persisted (session history)
+        +-- projects/                    <- WORKDIR (where users run Claude)
+            +-- .claude/                 <- Local auto-memory (separate from global)
+        ```
+
+        This structure separates global config (`/workspace/.claude/`) from local auto-memory (`/workspace/projects/.claude/`), mirroring the experience of running Claude Code locally.
+
+        **What persists:**
+
+        | Data | Location | Persisted? |
+        |------|----------|------------|
+        | Session history | `/workspace/.claude/projects/` | Yes |
+        | Global memory | `/workspace/.claude/memory/` | Yes |
+        | Local auto-memory | `/workspace/projects/.claude/` | Yes |
+        | Project files | `/workspace/projects/` | Yes |
+        | Skills | `/etc/claude-skills/` (symlinked to `$CLAUDE_CONFIG_DIR/skills/`) | ConfigMap (re-mounted each restart) |
+        | Settings | `${CLAUDE_CONFIG_DIR}/settings.json` | Copied from ConfigMap on first start |
+
+        The entrypoint creates a symlink `~/.claude` -> `/workspace/.claude/` so that standard `~/.claude/` paths work as expected.
+
+        **Disabling persistence:** Set `CLAUDE_CONFIG_DIR` to a non-PVC path:
+
+        ```yaml
+        env:
+          - name: CLAUDE_CONFIG_DIR
+            value: "/tmp/.claude"
+        ```
+
+        ### Injecting Skills
+
+        Skills extend Claude Code with custom instructions. They are auto-discovered from `~/.claude/skills/`. The skills ConfigMap is mounted at `/etc/claude-skills/` and the entrypoint symlinks it into `$CLAUDE_CONFIG_DIR/skills/`. Each skill must be in a subdirectory containing a `SKILL.md` file.
+
+        **Upgrading from older deployments:** If your PVC has an existing `skills/` directory from a previous deployment, the entrypoint automatically moves it to `skills.bak/` before creating the symlink.
+
+        **1. Create a SKILL.md file:**
+
+        ```markdown
+        # Code Review
+
+        When reviewing code, analyze for:
+
+        1. **Correctness** - Logic errors, edge cases, off-by-one errors
+        2. **Security** - Input validation, injection risks, hardcoded secrets
+        3. **Performance** - Unnecessary loops, N+1 queries, missing indexes
+
+        Provide feedback as:
+        - **Must Fix** - Bugs or security issues
+        - **Should Fix** - Performance or maintainability concerns
+        - **Consider** - Style suggestions or minor improvements
+        ```
+
+        **2. Create a ConfigMap from your skill files:**
+
+        ```bash
+        oc create configmap <skills-configmap-name> \
+          --from-file=code-review-skill=./skills/code-review/SKILL.md
+        ```
+
+        The ConfigMap name must match your deployment manifest (e.g., `claude-skills`, `claude-vllm-skills`).
+
+        **3. Add an `items` mapping to the skills volume in your deployment manifest:**
+
+        The `items` mapping is required so Kubernetes creates the `<skill-name>/SKILL.md` subdirectory structure that Claude Code expects. Without it, the file appears as a flat file and won't be discovered.
+
+        ```yaml
+        volumes:
+          - name: skills
+            configMap:
+              name: <skills-configmap-name>
+              optional: true
+              items:
+                - key: code-review-skill
+                  path: code-review/SKILL.md
+        ```
+
+        Each `items` entry maps a ConfigMap key to a path under the mount point. For multiple skills, add one entry per skill. For many skills, consider a PVC instead of a ConfigMap.
+
+        ### MCP Server Configuration
+
+        MCP (Model Context Protocol) servers extend Claude Code with additional tools. Configure via mounted config file or environment variable.
+
+        **Config file format:**
+
+        ```json
+        {
+          "mcpServers": {
+            "remote-api": {
+              "type": "http",
+              "url": "https://mcp.example.com/v1",
+              "headers": {
+                "Authorization": "Bearer ${API_TOKEN}"
+              }
+            },
+            "local-tool": {
+              "command": "/usr/bin/my-tool",
+              "args": ["--flag"],
+              "env": {
+                "TOOL_CONFIG": "/etc/tool.conf"
+              }
+            }
+          }
+        }
+        ```
+
+        **GitHub MCP example** (requires a [Personal Access Token](https://github.com/settings/tokens)). The `${GITHUB_PAT}` variable is expanded at runtime from the container's environment; inject it via a Kubernetes Secret (see below):
+
+        ```json
+        {
+          "mcpServers": {
+            "github": {
+              "type": "http",
+              "url": "https://api.githubcopilot.com/mcp/",
+              "headers": {
+                "Authorization": "Bearer ${GITHUB_PAT}"
+              }
+            }
+          }
+        }
+        ```
+
+        **Injecting secrets:** Environment variables like `${API_TOKEN}` can be injected via Kubernetes Secrets in the Deployment env section:
+
+        ```yaml
+        env:
+          - name: API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: mcp-credentials
+                key: token
+        ```
+
+        Avoid hardcoding credentials in ConfigMap JSON.
+
+        **Transport types:**
+
+        | Type | Use case | Requirements |
+        |------|----------|--------------|
+        | `http` | Remote MCP servers (recommended) | Network access to endpoint |
+        | `sse` | Legacy remote servers | Network access to endpoint |
+        | `command` | Local process-based servers | Executable must exist in container |
+
+        The base image includes `git`, `curl`, `jq`, `bash`, and `python3`. Command-based MCP servers requiring `npx` or other runtimes need a custom image (see [Extending the Container Image](#extending-the-container-image)).
+
+        **Option 1: Mounted config file.** The manifests mount a ConfigMap to `/etc/mcp/config.json`. Update the ConfigMap (name varies by deployment: `claude-mcp-config`, `claude-vertex-mcp-config`, `claude-vllm-mcp-config`, or `claude-ogx-vllm-mcp-config`):
+
+        ```bash
+        oc patch configmap claude-mcp-config -p '{
+          "data": {
+            "config.json": "{\"mcpServers\":{\"my-api\":{\"type\":\"http\",\"url\":\"https://mcp.example.com/v1\"}}}"
+          }
+        }'
+        oc rollout restart deployment/claude-code
+        ```
+
+        **Option 2: Environment variable.** Set `MCP_CONFIG_JSON` with inline JSON in the Deployment spec:
+
+        ```yaml
+        - name: MCP_CONFIG_JSON
+          value: '{"mcpServers":{"my-api":{"type":"http","url":"https://mcp.example.com/v1"}}}'
+        ```
+
+        ### Workspace Instructions (CLAUDE.md)
+
+        Mount a `CLAUDE.md` file to the workspace directory to inject project-specific instructions:
+
+        ```bash
+        oc create configmap claude-workspace-instructions \
+          --from-file=CLAUDE.md=./CLAUDE.md
+        ```
+
+        Add to the deployment manifest:
+
+        ```yaml
+        # volumeMounts section:
+        - name: workspace-instructions
+          mountPath: /workspace/CLAUDE.md
+          subPath: CLAUDE.md
+          readOnly: true
+
+        # volumes section:
+        - name: workspace-instructions
+          configMap:
+            name: claude-workspace-instructions
+        ```
+
+        Claude Code automatically reads CLAUDE.md from the working directory and applies the instructions to the session.
+
+        ### Overriding settings.json
+
+        All manifests include a settings ConfigMap staged at a read-only path (`/etc/claude-config/settings.json`). On first start, the entrypoint copies it to `${CLAUDE_CONFIG_DIR}/settings.json` on the writable PVC. On subsequent restarts, the existing file is preserved so that runtime changes (e.g., hooks added by `mlflow autolog`) survive. To force a settings reset, delete the file from the PVC before restarting. The ConfigMap name varies by deployment (`claude-settings`, `claude-vertex-settings`, `claude-vllm-settings`, or `claude-ogx-vllm-settings`):
+
+        ```bash
+        oc patch configmap claude-settings -p '{
+          "data": {
+            "settings.json": "{\n  \"model\": \"your-model-id\"\n}"
+          }
+        }'
+        oc rollout restart deployment/claude-code
+        ```
+
+        Or edit the ConfigMap in the manifest YAML before applying:
+
+        ```yaml
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: claude-settings
+        data:
+          settings.json: |
+            {
+              "model": "your-model-id"
+            }
+        ```
+
+        ### Extending the Container Image
+
+        The base image includes `git`, `curl`, `jq`, `bash`, and `python3`. For real coding workflows, add language runtimes so the agent can run tests, lint, and build. Including the runtimes your project uses significantly improves agent output quality since the agent can run tests and catch its own mistakes.
+
+        The following example adds common development tools. Remove any you don't need:
+
+        ```dockerfile
+        # In the "Install System Dependencies" section of the Containerfile
+        RUN microdnf install -y --nodocs \
+                git \
+                curl \
+                jq \
+                python3.12 \
+                python3.12-pip \
+                # Build tools
+                make \
+                gcc \
+                tar \
+                unzip \
+                patch \
+                diffutils \
+                which \
+                # Node.js (includes npm)
+                nodejs \
+                # Go
+                golang \
+                # Java
+                java-21-openjdk-devel \
+                maven \
+                # Rust
+                rust \
+                cargo \
+            && microdnf clean all \
+            && rm -rf /var/cache/yum
+        ```
+
+        The GitHub CLI (`gh`) is not available in UBI repos and must be installed separately:
+
+        ```dockerfile
+        # Install GitHub CLI
+        ARG GH_VERSION=2.74.1
+        RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin --strip-components=2 "gh_${GH_VERSION}_linux_amd64/bin/gh"
+        ```
+
+        ---
+
+        ## MLflow Tracing (Optional)
+
+        The container image includes MLflow 3.12 with the `kubernetes-namespaced` auth plugin, and the entrypoint automatically configures tracing when `MLFLOW_TRACKING_URI` is set. No changes to the Containerfile or entrypoint are needed.
+
+        ### Prerequisites
+
+        - An MLflow instance running on your RHOAI cluster with a workspace matching your namespace.
+
+        ### 1. Grant RBAC
+
+        ```bash
+        oc adm policy add-role-to-user edit -z default -n <your-namespace>
+        ```
+
+        For production, use a dedicated service account with least-privilege RBAC scoped to the permissions MLflow's `kubernetes-namespaced` auth plugin requires.
+
+        ### 2. Add MLflow env vars to your deployment manifest
+
+        Uncomment the MLflow env vars in your deployment manifest (all four manifests include commented-out placeholders), or add these to the `env` section:
+
+        ```yaml
+        - name: MLFLOW_TRACKING_URI
+          value: "https://mlflow.<rhoai-namespace>.svc:8443/mlflow"
+        - name: MLFLOW_TRACKING_AUTH
+          value: "kubernetes-namespaced"
+        - name: MLFLOW_WORKSPACE
+          value: "<your-namespace>"
+        - name: MLFLOW_EXPERIMENT_NAME
+          value: "claude-code-traces"
+        - name: MLFLOW_TRACKING_INSECURE_TLS
+          value: "true"  # dev/test only; production should use proper TLS certificates
+        ```
+
+        The `<rhoai-namespace>` is commonly `redhat-ods-applications`. The `/mlflow` path suffix is required for MLflow 3.12+.
+
+        If your deployment is already running, re-apply the manifest and restart the pod to pick up the new env vars:
+
+        ```bash
+        oc apply -f <your-deployment-manifest>.yaml
+        oc rollout restart deployment/<deployment-name>
+        ```
+
+        ### 3. Verify
+
+        ```bash
+        # Check startup logs for MLflow initialization
+        oc logs deployment/<deployment-name> | grep -i mlflow
+
+        # Run a test prompt
+        oc exec deployment/<deployment-name> -- bash -c '
+          ~/.claude/claude-run -p "What is 2+2?"
+        '
+
+        # Check your MLflow UI for a new trace under the experiment name
+        ```
+
+        ### 4. View traces in the MLflow UI
+
+        Find the MLflow UI URL from the ConsoleLink:
+
+        ```bash
+        oc get consolelink mlflow -o jsonpath='{.spec.href}'
+        ```
+
+        This typically returns a URL through the RHOAI data science gateway (e.g., `https://rh-ai.<cluster-domain>/mlflow`). Open that URL in your browser and log in with the same OpenShift identity that deployed the agent. The MLflow workspace maps to the Kubernetes namespace, so you must have RBAC access to the agent's namespace to see its experiments and traces.
+
+        After login, select your workspace (the namespace name, e.g., `my-claude-code`) and navigate to the experiment you configured in `MLFLOW_EXPERIMENT_NAME`.
+
+        > **Note:** The direct MLflow route (`mlflow-<rhoai-namespace>.<cluster-domain>`) does not handle browser authentication. Always use the gateway URL from the ConsoleLink, which routes through OAuth.
+
+        ### What gets traced
+
+        Each session captures tool call sequences, token counts (input/output/total), session duration, model name, and status as OTel spans. The stop-hook fires after the session ends, so there is zero impact on agent response times. The trace schema works identically across all four backends.
+
+        ### MLflow version options
+
+        The default Containerfile uses MLflow 3.12 with a Python hook. MLflow 3.14+ also supports an npm plugin approach — uncomment the npm plugin env var in your deployment manifest to enable it. The plugin must be built from [upstream master](https://github.com/mlflow/mlflow/tree/master/libs/typescript) until the next plugin release syncs the fix. See [mlflow-tracing.md](mlflow-tracing.md) for a comparison of both approaches.
+
+        > **TLS note:** The npm plugin currently requires `NODE_TLS_REJECT_UNAUTHORIZED=0` or `NODE_EXTRA_CA_CERTS` for clusters with non-public TLS certificates. Both are process-wide Node.js settings. Upstream work is in progress to support `MLFLOW_TRACKING_INSECURE_TLS` and `MLFLOW_TRACKING_SERVER_CERT_PATH` scoped to MLflow connections only ([mlflow#24140](https://github.com/mlflow/mlflow/issues/24140)). Kubernetes-native auth (`MLFLOW_TRACKING_AUTH`) is also being added to the TypeScript SDK ([mlflow#24141](https://github.com/mlflow/mlflow/issues/24141)).
+
+        For detailed tracing investigation results and benchmark data, see [mlflow-tracing.md](mlflow-tracing.md).
+
+        ---
+
+        ## Security Considerations
+
+        ### SKIP_PERMISSIONS
+
+        The deployment manifests set `SKIP_PERMISSIONS=true` by default, passing `--dangerously-skip-permissions` to Claude Code. This disables all permission prompts, including file-system write confirmations and confirmation of destructive operations (e.g., `git push --force`).
+
+        **Why it's enabled by default:**
+
+        - The container runs as non-root with dropped capabilities and seccomp profiles
+        - Claude only has access to the isolated `/workspace` PVC, not host filesystems
+        - Permission prompts don't work well in non-interactive `oc exec` scenarios
+        - One of the main advantages of running Claude Code in an isolated container is enabling less-interrupted workflows
+
+        **Tradeoffs:** Running in an isolated container removes much of the reason you would normally keep permission checks in place: the container cannot access data that is not explicitly mounted into it. However, skipping permissions also disables guardrails against destructive operations on external services the agent can reach, such as force-pushing to a Git remote or making unintended API calls via MCP servers. If you are running interactively and want an extra layer of confirmation, you can disable `SKIP_PERMISSIONS`. But for headless or automated usage, permission prompts are not practical, and you should rely on the repository safeguards described below instead.
+
+        To disable, set `SKIP_PERMISSIONS=false` in the deployment manifest or remove the variable.
+
+        ### Repository Safeguards
+
+        When an AI agent has push access to a Git repository, ensure the repository has protections against mistakes. This is especially important with `SKIP_PERMISSIONS=true` and when using less capable models that are more likely to make errors such as committing directly to main, force-pushing, or merging their own PRs.
+
+        **Recommended protections:**
+
+        - **Branch protection rules**: Protect your main/default branch so direct pushes are blocked, forcing all changes through pull requests. On GitHub: Settings > Branches > Branch protection rules.
+        - **Required pull request reviews**: Require at least one approval from someone other than the PR author before merging. This prevents the agent from opening and immediately merging a PR without human review.
+        - **Limit PAT scope**: When creating the GitHub Personal Access Token used by the agent, grant only the minimum permissions needed. See [GitHub's documentation on token scopes](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) for fine-grained token options.
+        - **Status checks**: Require CI checks (tests, linting) to pass before a PR can be merged, so broken code cannot be merged even if a review is approved.
+
+        These protections apply regardless of whether you are using Claude Code or any other AI coding tool. They are standard best practices for collaborative development, but become critical when an automated agent has commit and push access.
+
+        ### Credential Isolation
+
+        When credentials such as GitHub PATs or API tokens are passed as environment variables or written to files inside the container, the agent can read them directly. This means the agent could inadvertently expose credentials in conversation output, commit messages, or through MCP server calls. This is a known limitation of the approach described in this guide.
+
+        For many use cases, this risk is acceptable when combined with the safeguards above: limiting PAT scope to the minimum required permissions, protecting branches, and requiring PR reviews. However, for environments with strict security requirements, the ideal approach is to isolate the agent from the credentials it depends on, so that it can use tools (like git push or GitHub APIs) without being able to see or exfiltrate the underlying secrets.
+
+        Container isolation solutions are actively exploring ways to provide this kind of separation. If credential isolation is a requirement for your deployment, consider evaluating such solutions as they mature.
+
+        ---
+
+        ## Troubleshooting
+
+        ### Network Connectivity (vLLM/OGX)
+
+        If the vLLM or OGX server is outside the cluster (e.g., on EC2 or another cloud), verify the pod can reach it:
+
+        ```bash
+        # Find the cluster's egress IP
+        oc exec deployment/claude-code-vllm -- curl -s ifconfig.me
+
+        # Test connectivity to the server
+        oc exec deployment/claude-code-vllm -- curl -s -o /dev/null -w "%{http_code}" http://YOUR_HOST:8000/v1/models
+        ```
+
+        Common causes of connection failure include security group rules, network policies, and firewalls. If the server uses IP-based access rules, add the cluster egress IP to the allow list (e.g., AWS security group inbound rule on TCP port 8000).
+
+        ### Context Window Errors
+
+        Models with insufficient context will fail with errors like:
+
+        ```text
+        API Error: 400 {"type":"error","error":{"type":"BadRequestError",
+        "message":"max_tokens must be at least 1, got -7214."}}
+        ```
+
+        This means the model's context window is too small to fit Claude Code's system prompt plus the requested output tokens. See [Context window configuration](#context-window-configuration) in Option C for how to configure the context window, autocompaction, and output budget.
+
+        ### OGX 404 Logs
+
+        When monitoring OGX logs, some 404 responses are normal:
+
+        ```bash
+        oc logs deployment/ogx --tail=50
+        ```
+
+        ```text
+        HEAD / 404        # Claude Code HTTP client probing
+        POST /v1/messages 404  # Initial probes (2x)
+        POST /v1/messages 200  # Successful request with "Using native /v1/messages passthrough"
+        ```
+
+        The 404s are caused by Claude Code's HTTP client probing behavior and do not indicate errors. The key indicator of success is seeing `Using native /v1/messages passthrough` followed by a 200 response.
+
+        ### Testing Endpoints Directly
+
+        To verify the vLLM or OGX server supports the Anthropic Messages API:
+
+        **vLLM:**
+
+        ```bash
+        # Health and model listing
+        curl -s "https://YOUR_VLLM_ENDPOINT/health"
+        curl -s "https://YOUR_VLLM_ENDPOINT/v1/models"
+
+        # Non-streaming request
+        curl -s -X POST "https://YOUR_VLLM_ENDPOINT/v1/messages" \
+          -H "Content-Type: application/json" \
+          -H "anthropic-version: 2023-06-01" \
+          -d '{
+            "model": "YOUR_MODEL_ID",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "What is 2+2? Reply with just the number."}]
+          }'
+
+        # Streaming request
+        curl -s -X POST "https://YOUR_VLLM_ENDPOINT/v1/messages" \
+          -H "Content-Type: application/json" \
+          -H "anthropic-version: 2023-06-01" \
+          -d '{
+            "model": "YOUR_MODEL_ID",
+            "max_tokens": 100,
+            "stream": true,
+            "messages": [{"role": "user", "content": "Say hello"}]
+          }'
+
+        # Tool calling (Claude Code uses tools extensively)
+        curl -s -X POST "https://YOUR_VLLM_ENDPOINT/v1/messages" \
+          -H "Content-Type: application/json" \
+          -H "anthropic-version: 2023-06-01" \
+          -d '{
+            "model": "YOUR_MODEL_ID",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "List files in the current directory"}],
+            "tools": [{"name": "bash", "description": "Run a bash command", "input_schema": {"type": "object", "properties": {"command": {"type": "string"}}, "required": ["command"]}}]
+          }'
+        ```
+
+        **OGX:** Use the same commands with your OGX route URL and the `vllm/` model prefix reported by `GET /v1/models`:
+
+        ```bash
+        OGX_URL=<your-ogx-route-host>
+        curl -s "https://$OGX_URL/v1/health"
+        curl -s "https://$OGX_URL/v1/models"
+
+        curl -s -X POST "https://$OGX_URL/v1/messages" \
+          -H "Content-Type: application/json" \
+          -H "anthropic-version: 2023-06-01" \
+          -d '{
+            "model": "vllm/YOUR_MODEL_ID",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "What is 2+2? Reply with just the number."}]
+          }'
+        ```
+
+        ### Model Aliasing
+
+        vLLM supports model aliasing via `--served-model-name`, letting you serve a model under a custom name without OGX:
+
+        ```yaml
+        command:
+          - python3
+          - -m
+          - vllm.entrypoints.openai.api_server
+          - --model
+          - openai/gpt-oss-120b
+          - --served-model-name
+          - my-custom-model-name
+        ```
+
+        Then set `CLAUDE_MODEL` on the Claude Code deployment to match:
+
+        ```bash
+        oc set env deployment/claude-code CLAUDE_MODEL=my-custom-model-name
+        ```
+
+        `--served-model-name` is a **replacement**, not an addition. The original HuggingFace model ID is no longer recognized after setting an alias. To keep both the original name and an alias, pass the flag twice: `--served-model-name openai/gpt-oss-120b --served-model-name my-alias`.
+
+        ### Interactive Wizard API Key Confirmation
+
+        When launching interactive mode, Claude Code's setup wizard includes an API key confirmation page. The behavior depends on which authentication env var you use:
+
+        - **`ANTHROPIC_AUTH_TOKEN`**: The key confirmation page is skipped entirely. This is what the vLLM and OGX manifests use. Set it to `"fake"` if your backend requires no authentication, or to a real token if it does.
+        - **`ANTHROPIC_API_KEY`**: The wizard prompts you to accept or reject the key. Use this for the Anthropic API (Option A) or any backend that requires an Anthropic-style API key. You must accept the key when prompted; see below for what happens if you reject it.
+
+        **If you reject an API key**, Claude Code stores the rejection in `/workspace/.claude/.claude.json` on the PVC and redirects you to browser-based authentication. Restarting the pod does not help because the rejection is persisted on the PVC. To recover, either fix the config file or delete the PVC and redeploy:
+
+        ```bash
+        # Option 1: Fix the config file
+        oc exec deployment/<your-deployment-name> -- python3 -c '
+        import json
+        f = "/workspace/.claude/.claude.json"
+        with open(f) as fh:
+            d = json.load(fh)
+        d["customApiKeyResponses"] = {"approved": [], "rejected": []}
+        with open(f, "w") as fh:
+            json.dump(d, fh, indent=2)
+        print("Fixed: cleared key rejections")
+        '
+
+        # Option 2: Delete PVC and redeploy (full fresh start)
+        oc delete pvc <your-workspace-pvc>
+        oc rollout restart deployment/<your-deployment-name>
+        ```
+
+        ### Test Scripts
+
+        For automated validation of vLLM endpoints and Claude Code functionality, see the test scripts in [vllm/tests/](vllm/tests/). Full documentation is in [vllm/README.md](vllm/README.md).
+
+        ---
+
+        ## Cleanup
+
+        Resources to delete, by deployment option:
+
+        **Option A (Anthropic API):**
+
+        ```bash
+        oc delete deployment claude-code
+        oc delete buildconfig claude-code
+        oc delete imagestream claude-code
+        oc delete secret claude-credentials
+        oc delete configmap claude-mcp-config claude-skills claude-settings
+        oc delete pvc claude-workspace
+        oc delete project my-claude-project
+        ```
+
+        **Option B (Vertex AI):**
+
+        ```bash
+        oc delete deployment claude-code-vertex
+        oc delete buildconfig claude-code
+        oc delete imagestream claude-code
+        oc delete secret claude-vertex-credentials
+        oc delete configmap claude-vertex-config claude-vertex-mcp-config claude-vertex-skills claude-vertex-settings
+        oc delete pvc claude-vertex-workspace
+        oc delete project my-claude-project
+        ```
+
+        **Option C (vLLM direct):**
+
+        ```bash
+        oc delete deployment claude-code-vllm
+        oc delete buildconfig claude-code
+        oc delete imagestream claude-code
+        oc delete configmap claude-vllm-settings claude-vllm-mcp-config claude-vllm-skills
+        oc delete pvc claude-vllm-workspace
+        oc delete project my-claude-project
+        ```
+
+        **Option D (OGX + vLLM):**
+
+        ```bash
+        oc delete deployment claude-code-ogx-vllm
+        oc delete buildconfig claude-code
+        oc delete imagestream claude-code
+        oc delete configmap claude-ogx-vllm-settings claude-ogx-vllm-mcp-config claude-ogx-vllm-skills
+        oc delete pvc claude-ogx-vllm-workspace
+        oc delete project my-claude-project
+        ```
+
+        ---
+
+        ## Known Limitations
+
+        ### Context Window Requirement
+
+        Claude Code sends a large internal system prompt (~23K tokens) with every request. Models with insufficient context will fail. Minimum: 32K tokens. Recommended: 128K+ for multi-turn conversations with tool use.
+
+        ### Open Source Model Quality
+
+        Claude Code is designed and optimized for Anthropic's Claude models. Open source models may produce lower quality results, particularly for complex multi-step tasks, tool use chains, and code generation. Including language runtimes in the container helps because the agent can run tests and iterate on its own output.
+
+        ### LLMInferenceService vs Standalone Deployment
+
+        The KServe `LLMInferenceService` CRD adds a `storage-initializer` init container that uses HF Xet for model downloads. This can stall on large models (60GB+) due to CDN timeouts, and the CRD does not expose init container env overrides. The standalone Deployment approach (used in [vllm/README.md](vllm/README.md)) lets vLLM download the model directly with standard HTTP, which is more reliable.
+
+        Use `LLMInferenceService` when you need the llm-d router/scheduler for multi-replica intelligent routing. Use standalone Deployment for single-replica setups or when the init container stalls.
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/claude-code
+      framework: claude-code
+      agentType: starter_kit
+    - name: openclaw
+      displayName: OpenClaw on OpenShift
+      description: Deploy OpenClaw on OpenShift with vLLM model serving, OAuth SSO, and production-grade security.
+      readme: |
+        # OpenClaw on OpenShift
+
+        > Tested: 2026-04-13 on OpenShift 4.19 (ROSA) with vLLM model serving
+
+        Deploy [OpenClaw](https://github.com/openclaw/openclaw) on Red Hat OpenShift with vLLM model serving — no cluster-admin required.
+
+        For the full deployment guide, see [docs/raw-deployment.md](docs/raw-deployment.md).
+
+        ## Prerequisites
+
+        - OpenShift 4.17+ with namespace-scoped access (`oc login`)
+        - A model serving endpoint (vLLM, KServe, or external API)
+        - Block storage class (gp3-csi, managed-csi, thin-csi) — not NFS
+
+        ## Quick Start
+
+        ```bash
+        oc new-project my-openclaw
+
+        # Edit manifests/02-configmap.yaml with your model endpoint
+        # Edit manifests/01-secret.yaml with your gateway token
+
+        oc apply -k manifests/
+        ```
+
+        ## Architecture
+
+        ```text
+                             +-----------------------+
+                             |   OpenShift Route     |
+                             |   (TLS edge)          |
+                             +-----------+-----------+
+                                         |
+                                         v
+                      +------------------+------------------+
+                      |            Service                   |
+                      |        (ClusterIP :18789)            |
+                      +------------------+------------------+
+                                         |
+                                         v
+                      +------------------+------------------+
+                      |              Pod                     |
+                      |  +--------------------------------+  |
+                      |  | gateway                        |  |
+                      |  | port 18789                     |  |
+                      |  +---------------+----------------+  |
+                      |                  |                   |
+                      |           +------+------+            |
+                      |           | PVC (5Gi)   |            |
+                      |           +-------------+            |
+                      +--------------------------------------+
+                                 |
+                                 | OpenAI-compatible API
+                                 v
+                      +---------------------------+
+                      |  vLLM / KServe / API      |
+                      +---------------------------+
+        ```
+
+        ## Files
+
+        | File | Description |
+        |------|-------------|
+        | `manifests/01-secret.yaml` | Gateway authentication token |
+        | `manifests/02-configmap.yaml` | Model endpoint and gateway configuration |
+        | `manifests/03-pvc.yaml` | Persistent storage for gateway state |
+        | `manifests/04-deployment.yaml` | OpenClaw gateway deployment |
+        | `manifests/05-service.yaml` | ClusterIP service |
+        | `manifests/06-route.yaml` | TLS edge route |
+        | `manifests/kustomization.yaml` | Kustomize entrypoint |
+        | `overlays/example/` | Example overlay for environment-specific config |
+        | `overlays/mlflow-tracing/` | MLflow tracing via OTel collector sidecar |
+        | `Containerfile.openshell` | OpenShell sandbox image build |
+
+        ## Customization
+
+        | What | Where |
+        |------|-------|
+        | Model endpoint URL | `overlays/<env>/configmap-patch.yaml` |
+        | Storage class | `overlays/<env>/kustomization.yaml` (patch) |
+        | Namespace | `overlays/<env>/kustomization.yaml` (`namespace:` field) |
+        | Gateway token | `manifests/01-secret.yaml` |
+        | Resource limits | Patch `manifests/04-deployment.yaml` |
+
+        ## Docs
+
+        | Document | Description |
+        |----------|-------------|
+        | [docs/raw-deployment.md](docs/raw-deployment.md) | Full deployment guide: configuration, validation, troubleshooting |
+        | [docs/mlflow-tracing.md](docs/mlflow-tracing.md) | MLflow tracing with OTel collector sidecar |
+        | [docs/model-compatibility.md](docs/model-compatibility.md) | Model testing results for agentic tool-calling |
+        | [docs/troubleshooting.md](docs/troubleshooting.md) | Common issues and fixes |
+        | [docs/installer-deployment.md](docs/installer-deployment.md) | Alternative deployment via [claw-installer](https://github.com/sallyom/claw-installer) |
+
+        ## Related Projects
+
+        - [OpenClaw](https://github.com/openclaw/openclaw) — Upstream project
+        - [claw-installer](https://github.com/sallyom/claw-installer) — Web-based deployment tool with OpenShift plugin
+        - [openclaw-on-openshift](https://github.com/aakankshaduggal/openclaw-on-openshift) — Source repo with full docs
+
+        ---
+
+        ## Running in an OpenShell Sandbox
+
+        To run OpenClaw inside an [OpenShell](https://github.com/NVIDIA/OpenShell-Community) sandbox, use the `Containerfile.openshell`. This builds on the shared base image (`sandboxes/base/`) and adds Node.js and the OpenClaw CLI on top.
+
+        ### Build the OpenShell-compatible image
+
+        ```bash
+        podman build --platform linux/amd64 -t openclaw-sandbox:latest -f Containerfile.openshell .
+        ```
+
+        ### Create a sandbox
+
+        ```bash
+        openshell sandbox create --from openclaw-sandbox:latest
+        ```
+
+        ### What `Containerfile.openshell` does
+
+        Builds on the shared base image (`quay.io/hmoghani/openshell-base`) which provides the `sandbox` user, system packages, and OpenShell entrypoint. This flavor adds:
+
+        - Node.js and npm (from UBI repos)
+        - OpenClaw via npm (version pinned, MIT)
+
+        ### Notes
+
+        - OpenShell's supervisor takes over as PID 1 and does not automatically start the OpenClaw gateway. Start it manually inside the sandbox: `openclaw gateway --bind loopback --auth none --port 18789 --allow-unconfigured`
+        - Build with `--platform linux/amd64` when targeting x86_64 clusters from Apple Silicon machines.
+        - Tested on OpenShell v0.0.58, OpenShift 4.21 (June 2026).
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/openclaw/deployment
+      framework: openclaw
+      agentType: starter_kit
+    - name: codex
+      displayName: Codex on OpenShift
+      description: Run OpenAI Codex CLI inside an OpenShell sandbox on OpenShift.
+      readme: |
+        # Codex — OpenShell Sandbox Deployment
+
+        This directory contains an OpenShell-compatible Containerfile for running [OpenAI Codex CLI](https://github.com/openai/codex) inside an OpenShell sandbox.
+
+        ## Prerequisites
+
+        - [Podman](https://podman.io/) or Docker installed
+        - [OpenShell CLI](https://github.com/NVIDIA/OpenShell-Community) installed
+        - An OpenShell gateway running
+
+        ## Build and Run
+
+        ```bash
+        podman build --platform linux/amd64 -t codex-sandbox:latest -f Containerfile.openshell .
+        openshell sandbox create --from codex-sandbox:latest -e OPENAI_API_KEY=sk-...
+        ```
+
+        ## What `Containerfile.openshell` does
+
+        Builds on the shared base image (`quay.io/hmoghani/openshell-base`) which provides the `sandbox` user, system packages, and OpenShell entrypoint. This flavor adds:
+
+        - Node.js and npm (from UBI repos)
+        - Codex CLI via npm (version pinned, Apache 2.0)
+
+        ## Notes
+
+        - OpenShell's supervisor takes over as PID 1 and does not automatically run the Codex CLI. Start it manually inside the sandbox.
+        - Build with `--platform linux/amd64` when targeting x86_64 clusters from Apple Silicon machines.
+        - Tested on OpenShell v0.0.58, OpenShift 4.21 (June 2026). Codex CLI version 0.139.0.
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/codex/deployment
+      framework: codex
+      agentType: starter_kit
+    - name: opencode
+      displayName: OpenCode on OpenShift
+      description: Run OpenCode inside an OpenShell sandbox on OpenShift.
+      readme: |
+        # OpenCode — OpenShell Sandbox Deployment
+
+        This directory contains an OpenShell-compatible Containerfile for running [OpenCode](https://github.com/sst/opencode) inside an OpenShell sandbox.
+
+        ## Prerequisites
+
+        - [Podman](https://podman.io/) or Docker installed
+        - [OpenShell CLI](https://github.com/NVIDIA/OpenShell-Community) installed
+        - An OpenShell gateway running
+
+        ## Build and Run
+
+        ```bash
+        podman build --platform linux/amd64 -t opencode-sandbox:latest -f Containerfile.openshell .
+        openshell sandbox create --from opencode-sandbox:latest
+        ```
+
+        ## What `Containerfile.openshell` does
+
+        Builds on the shared base image (`quay.io/hmoghani/openshell-base`) which provides the `sandbox` user, system packages, and OpenShell entrypoint. This flavor adds:
+
+        - Node.js and npm (from UBI repos)
+        - OpenCode via npm (version pinned, MIT)
+
+        ## RHOAI Deployment
+
+        For deploying OpenCode on Red Hat OpenShift AI with OAuth, kustomize manifests, and production configuration, see [DEPLOYMENT.md](DEPLOYMENT.md).
+
+        ## Notes
+
+        - OpenShell's supervisor takes over as PID 1 and does not automatically run OpenCode. Start it manually inside the sandbox.
+        - Build with `--platform linux/amd64` when targeting x86_64 clusters from Apple Silicon machines.
+        - Tested on OpenShell v0.0.58, OpenShift 4.21 (June 2026). OpenCode version 1.17.1.
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/opencode/deployment
+      framework: opencode
+      agentType: starter_kit

--- a/data/redhat-agents-index.yaml
+++ b/data/redhat-agents-index.yaml
@@ -1,0 +1,38 @@
+source: Red Hat Agents
+repository: red-hat-data-services/agentic-starter-kits
+branch: main
+agents:
+  # Template agents (have agent.yaml upstream — metadata auto-fetched)
+  - path: agents/langgraph/templates/react_agent
+  - path: agents/langgraph/templates/agentic_rag
+  - path: agents/langgraph/templates/react_with_database_memory
+  - path: agents/langgraph/templates/human_in_the_loop
+  - path: agents/crewai/templates/websearch_agent
+  - path: agents/llamaindex/templates/websearch_agent
+  - path: agents/vanilla_python/templates/openai_responses_agent
+  - path: agents/autogen/templates/mcp_agent
+  - path: agents/google/templates/adk
+  - path: agents/langflow/templates/simple_tool_calling_agent
+  - path: agents/a2a/templates/langgraph_crewai_agent
+
+  # Deployment-only agents (no agent.yaml upstream — metadata inline)
+  - path: agents/claude-code
+    name: claude-code
+    displayName: "Claude Code on OpenShift"
+    framework: claude-code
+    description: "Deploy Claude Code on OpenShift with multiple backend options (Anthropic API, Vertex AI, vLLM, OGX)."
+  - path: agents/openclaw/deployment
+    name: openclaw
+    displayName: "OpenClaw on OpenShift"
+    framework: openclaw
+    description: "Deploy OpenClaw on OpenShift with vLLM model serving, OAuth SSO, and production-grade security."
+  - path: agents/codex/deployment
+    name: codex
+    displayName: "Codex on OpenShift"
+    framework: codex
+    description: "Run OpenAI Codex CLI inside an OpenShell sandbox on OpenShift."
+  - path: agents/opencode/deployment
+    name: opencode
+    displayName: "OpenCode on OpenShift"
+    framework: opencode
+    description: "Run OpenCode inside an OpenShell sandbox on OpenShift."

--- a/internal/catalog/agent_catalog.go
+++ b/internal/catalog/agent_catalog.go
@@ -41,15 +41,21 @@ func CreateAgentsCatalog(indexPath, catalogPath, branchOverride string, skipEnri
 	log.Printf("Processing agents index: %s (%d entries, repo: %s, branch: %s)",
 		indexPath, len(index.Agents), index.Repository, index.Branch)
 
+	// When enrichment is enabled, resolve the branch to a commit SHA so that
+	// raw.githubusercontent.com URLs work for slash-containing branch names
+	// (e.g. releases/rhoai-2.18).
+	var rawRef string
 	if !skipEnrichment {
-		if err := github.ValidateBranch(index.Repository, index.Branch); err != nil {
+		sha, err := github.ValidateBranch(index.Repository, index.Branch)
+		if err != nil {
 			return fmt.Errorf("branch validation failed: %v", err)
 		}
+		rawRef = sha
 	}
 
 	var agents []types.AgentMetadata
 	for _, entry := range index.Agents {
-		agent, err := buildAgentMetadata(index.Repository, index.Branch, entry, skipEnrichment)
+		agent, err := buildAgentMetadata(index.Repository, index.Branch, rawRef, entry, skipEnrichment)
 		if err != nil {
 			log.Printf("Warning: skipping agent at path %q: %v", entry.Path, err)
 			continue
@@ -83,11 +89,13 @@ func CreateAgentsCatalog(indexPath, catalogPath, branchOverride string, skipEnri
 
 // buildAgentMetadata constructs an AgentMetadata by fetching from GitHub or
 // falling back to inline overrides from the index entry.
-func buildAgentMetadata(repo, branch string, entry types.AgentIndexEntry, skipEnrichment bool) (*types.AgentMetadata, error) {
+// rawRef is the commit SHA used for raw.githubusercontent.com URLs (safe for
+// slash-containing branch names); branch is used for the human-readable tree URL.
+func buildAgentMetadata(repo, branch, rawRef string, entry types.AgentIndexEntry, skipEnrichment bool) (*types.AgentMetadata, error) {
 	agent := &types.AgentMetadata{}
 
 	if !skipEnrichment {
-		upstream, err := github.FetchAgentYAML(repo, branch, entry.Path)
+		upstream, err := github.FetchAgentYAML(repo, rawRef, entry.Path)
 		if errors.Is(err, github.ErrNotFound) {
 			log.Printf("  No agent.yaml at %s, using index overrides", entry.Path)
 		} else if err != nil {
@@ -101,7 +109,7 @@ func buildAgentMetadata(repo, branch string, entry types.AgentIndexEntry, skipEn
 			forwardExtraAsCustomProperties(agent, upstream.Extra)
 		}
 
-		readme, err := github.FetchReadme(repo, branch, entry.Path)
+		readme, err := github.FetchReadme(repo, rawRef, entry.Path)
 		if err != nil {
 			log.Printf("  Warning: failed to fetch README for %s: %v", entry.Path, err)
 		} else if readme != "" {

--- a/internal/catalog/agent_catalog.go
+++ b/internal/catalog/agent_catalog.go
@@ -1,6 +1,8 @@
 package catalog
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -8,8 +10,6 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
-
-	"errors"
 
 	"github.com/opendatahub-io/model-metadata-collection/internal/github"
 	"github.com/opendatahub-io/model-metadata-collection/pkg/types"
@@ -84,9 +84,7 @@ func CreateAgentsCatalog(indexPath, catalogPath, branchOverride string, skipEnri
 // buildAgentMetadata constructs an AgentMetadata by fetching from GitHub or
 // falling back to inline overrides from the index entry.
 func buildAgentMetadata(repo, branch string, entry types.AgentIndexEntry, skipEnrichment bool) (*types.AgentMetadata, error) {
-	agent := &types.AgentMetadata{
-		AgentType: "starter_kit",
-	}
+	agent := &types.AgentMetadata{}
 
 	if !skipEnrichment {
 		upstream, err := github.FetchAgentYAML(repo, branch, entry.Path)
@@ -100,6 +98,7 @@ func buildAgentMetadata(repo, branch string, entry types.AgentIndexEntry, skipEn
 			agent.Framework = upstream.Framework
 			agent.Description = upstream.Description
 			agent.Env = transformEnvVars(upstream)
+			forwardExtraAsCustomProperties(agent, upstream.Extra)
 		}
 
 		readme, err := github.FetchReadme(repo, branch, entry.Path)
@@ -155,6 +154,36 @@ func transformEnvVars(upstream *types.UpstreamAgentYAML) []types.AgentEnvVar {
 		envVars = append(envVars, types.AgentEnvVar{Name: name, Required: false})
 	}
 	return envVars
+}
+
+// forwardExtraAsCustomProperties takes unknown fields from the upstream agent.yaml
+// and adds them to the agent's customProperties as MetadataStringValue entries.
+// Arrays and objects are JSON-encoded; scalars are converted to strings.
+func forwardExtraAsCustomProperties(agent *types.AgentMetadata, extra map[string]interface{}) {
+	if len(extra) == 0 {
+		return
+	}
+	if agent.CustomProperties == nil {
+		agent.CustomProperties = make(map[string]types.MetadataValue)
+	}
+	for key, val := range extra {
+		var strVal string
+		switch v := val.(type) {
+		case string:
+			strVal = v
+		default:
+			jsonBytes, err := json.Marshal(v)
+			if err != nil {
+				log.Printf("  Warning: could not serialize extra field %q: %v", key, err)
+				continue
+			}
+			strVal = string(jsonBytes)
+		}
+		agent.CustomProperties[key] = types.MetadataValue{
+			MetadataType: "MetadataStringValue",
+			StringValue:  strVal,
+		}
+	}
 }
 
 // agentSupportTierFromSource maps an index Source value to a supportTier string.

--- a/internal/catalog/agent_catalog.go
+++ b/internal/catalog/agent_catalog.go
@@ -1,0 +1,175 @@
+package catalog
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"errors"
+
+	"github.com/opendatahub-io/model-metadata-collection/internal/github"
+	"github.com/opendatahub-io/model-metadata-collection/pkg/types"
+	"github.com/opendatahub-io/model-metadata-collection/pkg/utils"
+)
+
+// CreateAgentsCatalog reads an agents index file, fetches metadata from GitHub
+// for each agent, and writes an aggregated catalog YAML.
+func CreateAgentsCatalog(indexPath, catalogPath, branchOverride string, skipEnrichment bool) error {
+	indexData, err := os.ReadFile(indexPath)
+	if err != nil {
+		return fmt.Errorf("error reading agents index file %s: %v", indexPath, err)
+	}
+
+	var index types.AgentsIndex
+	if err := yaml.Unmarshal(indexData, &index); err != nil {
+		return fmt.Errorf("error parsing agents index file %s: %v", indexPath, err)
+	}
+
+	if index.Repository == "" {
+		return fmt.Errorf("agents index file %s missing required field: repository", indexPath)
+	}
+	if branchOverride != "" {
+		index.Branch = branchOverride
+	} else if index.Branch == "" {
+		index.Branch = "main"
+	}
+
+	log.Printf("Processing agents index: %s (%d entries, repo: %s, branch: %s)",
+		indexPath, len(index.Agents), index.Repository, index.Branch)
+
+	if !skipEnrichment {
+		if err := github.ValidateBranch(index.Repository, index.Branch); err != nil {
+			return fmt.Errorf("branch validation failed: %v", err)
+		}
+	}
+
+	var agents []types.AgentMetadata
+	for _, entry := range index.Agents {
+		agent, err := buildAgentMetadata(index.Repository, index.Branch, entry, skipEnrichment)
+		if err != nil {
+			log.Printf("Warning: skipping agent at path %q: %v", entry.Path, err)
+			continue
+		}
+		agents = append(agents, *agent)
+		log.Printf("  Loaded agent: %s", agent.Name)
+	}
+
+	catalog := types.AgentsCatalog{
+		Source: index.Source,
+		Agents: agents,
+	}
+
+	catalogDir := filepath.Dir(catalogPath)
+	if err := os.MkdirAll(catalogDir, 0755); err != nil {
+		return fmt.Errorf("error creating catalog output directory: %v", err)
+	}
+
+	output, err := utils.MarshalYAMLWithNewline(&catalog)
+	if err != nil {
+		return fmt.Errorf("error marshaling agents catalog: %v", err)
+	}
+
+	if err := os.WriteFile(catalogPath, output, 0644); err != nil {
+		return fmt.Errorf("error writing agents catalog file: %v", err)
+	}
+
+	log.Printf("Successfully created %s with %d agents", catalogPath, len(agents))
+	return nil
+}
+
+// buildAgentMetadata constructs an AgentMetadata by fetching from GitHub or
+// falling back to inline overrides from the index entry.
+func buildAgentMetadata(repo, branch string, entry types.AgentIndexEntry, skipEnrichment bool) (*types.AgentMetadata, error) {
+	agent := &types.AgentMetadata{
+		AgentType: "starter_kit",
+	}
+
+	if !skipEnrichment {
+		upstream, err := github.FetchAgentYAML(repo, branch, entry.Path)
+		if errors.Is(err, github.ErrNotFound) {
+			log.Printf("  No agent.yaml at %s, using index overrides", entry.Path)
+		} else if err != nil {
+			return nil, fmt.Errorf("failed to fetch agent.yaml for %s: %v", entry.Path, err)
+		} else {
+			agent.Name = upstream.Name
+			agent.DisplayName = upstream.DisplayName
+			agent.Framework = upstream.Framework
+			agent.Description = upstream.Description
+			agent.Env = transformEnvVars(upstream)
+		}
+
+		readme, err := github.FetchReadme(repo, branch, entry.Path)
+		if err != nil {
+			log.Printf("  Warning: failed to fetch README for %s: %v", entry.Path, err)
+		} else if readme != "" {
+			agent.Readme = readme
+		}
+	}
+
+	applyIndexOverrides(agent, entry)
+
+	agent.RepositoryUrl = fmt.Sprintf("https://github.com/%s/tree/%s/%s", repo, branch, entry.Path)
+
+	if agent.Name == "" {
+		return nil, fmt.Errorf("agent at path %q has no name (not in agent.yaml and no index override)", entry.Path)
+	}
+	if agent.Description == "" {
+		return nil, fmt.Errorf("agent %q missing required field: description", agent.Name)
+	}
+	if agent.Framework == "" {
+		return nil, fmt.Errorf("agent %q missing required field: framework", agent.Name)
+	}
+
+	return agent, nil
+}
+
+// applyIndexOverrides applies inline metadata from the index entry, filling in
+// any fields that are still empty (index values don't overwrite fetched data).
+func applyIndexOverrides(agent *types.AgentMetadata, entry types.AgentIndexEntry) {
+	if agent.Name == "" && entry.Name != "" {
+		agent.Name = entry.Name
+	}
+	if agent.DisplayName == "" && entry.DisplayName != "" {
+		agent.DisplayName = entry.DisplayName
+	}
+	if agent.Framework == "" && entry.Framework != "" {
+		agent.Framework = entry.Framework
+	}
+	if agent.Description == "" && entry.Description != "" {
+		agent.Description = entry.Description
+	}
+}
+
+// transformEnvVars converts the upstream agent.yaml env format (required/optional
+// string lists) into the flat catalog format ([]AgentEnvVar with name+required).
+func transformEnvVars(upstream *types.UpstreamAgentYAML) []types.AgentEnvVar {
+	var envVars []types.AgentEnvVar
+	for _, name := range upstream.Env.Required {
+		envVars = append(envVars, types.AgentEnvVar{Name: name, Required: true})
+	}
+	for _, name := range upstream.Env.Optional {
+		envVars = append(envVars, types.AgentEnvVar{Name: name, Required: false})
+	}
+	return envVars
+}
+
+// agentSupportTierFromSource maps an index Source value to a supportTier string.
+// Currently unused — kept as a stub for future use if agent sources need tiered support.
+//
+//nolint:unused
+func agentSupportTierFromSource(source string) string {
+	switch strings.ToLower(strings.TrimSpace(source)) {
+	case "red hat agents":
+		return "redHatSupported"
+	case "partner agents":
+		return "partnerSupported"
+	case "community agents":
+		return "communitySupported"
+	default:
+		return ""
+	}
+}

--- a/internal/catalog/agent_catalog_test.go
+++ b/internal/catalog/agent_catalog_test.go
@@ -150,9 +150,6 @@ func TestCreateAgentsCatalogSkipEnrichment(t *testing.T) {
 	if agent.Name != "claude-code" {
 		t.Errorf("expected name 'claude-code', got %q", agent.Name)
 	}
-	if agent.AgentType != "starter_kit" {
-		t.Errorf("expected agentType 'starter_kit', got %q", agent.AgentType)
-	}
 	if agent.RepositoryUrl != "https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/claude-code" {
 		t.Errorf("unexpected repositoryUrl: %q", agent.RepositoryUrl)
 	}

--- a/internal/catalog/agent_catalog_test.go
+++ b/internal/catalog/agent_catalog_test.go
@@ -1,0 +1,325 @@
+package catalog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/opendatahub-io/model-metadata-collection/pkg/types"
+)
+
+func TestTransformEnvVars(t *testing.T) {
+	upstream := &types.UpstreamAgentYAML{}
+	upstream.Env.Required = []string{"API_KEY", "BASE_URL", "MODEL_ID"}
+	upstream.Env.Optional = []string{"PORT", "CONTAINER_IMAGE"}
+
+	result := transformEnvVars(upstream)
+
+	if len(result) != 5 {
+		t.Fatalf("expected 5 env vars, got %d", len(result))
+	}
+
+	// Required vars come first
+	for i, name := range []string{"API_KEY", "BASE_URL", "MODEL_ID"} {
+		if result[i].Name != name || !result[i].Required {
+			t.Errorf("env[%d]: expected {%s, true}, got {%s, %v}", i, name, result[i].Name, result[i].Required)
+		}
+	}
+
+	// Optional vars follow
+	for i, name := range []string{"PORT", "CONTAINER_IMAGE"} {
+		idx := i + 3
+		if result[idx].Name != name || result[idx].Required {
+			t.Errorf("env[%d]: expected {%s, false}, got {%s, %v}", idx, name, result[idx].Name, result[idx].Required)
+		}
+	}
+}
+
+func TestTransformEnvVarsEmpty(t *testing.T) {
+	upstream := &types.UpstreamAgentYAML{}
+	result := transformEnvVars(upstream)
+	if len(result) != 0 {
+		t.Errorf("expected 0 env vars for empty upstream, got %d", len(result))
+	}
+}
+
+func TestApplyIndexOverrides(t *testing.T) {
+	t.Run("fills empty fields from index", func(t *testing.T) {
+		agent := &types.AgentMetadata{}
+		entry := types.AgentIndexEntry{
+			Name:        "test-agent",
+			DisplayName: "Test Agent",
+			Framework:   "langgraph",
+			Description: "A test agent",
+		}
+		applyIndexOverrides(agent, entry)
+
+		if agent.Name != "test-agent" {
+			t.Errorf("expected name 'test-agent', got %q", agent.Name)
+		}
+		if agent.DisplayName != "Test Agent" {
+			t.Errorf("expected displayName 'Test Agent', got %q", agent.DisplayName)
+		}
+		if agent.Framework != "langgraph" {
+			t.Errorf("expected framework 'langgraph', got %q", agent.Framework)
+		}
+		if agent.Description != "A test agent" {
+			t.Errorf("expected description 'A test agent', got %q", agent.Description)
+		}
+	})
+
+	t.Run("does not overwrite existing fields", func(t *testing.T) {
+		agent := &types.AgentMetadata{
+			Name:        "fetched-name",
+			DisplayName: "Fetched Display Name",
+			Framework:   "crewai",
+			Description: "Fetched description",
+		}
+		entry := types.AgentIndexEntry{
+			Name:        "override-name",
+			DisplayName: "Override Display Name",
+			Framework:   "autogen",
+			Description: "Override description",
+		}
+		applyIndexOverrides(agent, entry)
+
+		if agent.Name != "fetched-name" {
+			t.Errorf("expected name 'fetched-name' (not overwritten), got %q", agent.Name)
+		}
+		if agent.Framework != "crewai" {
+			t.Errorf("expected framework 'crewai' (not overwritten), got %q", agent.Framework)
+		}
+	})
+}
+
+func TestCreateAgentsCatalogSkipEnrichment(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Index with only deployment-only agents (which have inline metadata).
+	// With skipEnrichment=true, template agents without overrides will be skipped.
+	index := types.AgentsIndex{
+		Source:     "Red Hat Agents",
+		Repository: "red-hat-data-services/agentic-starter-kits",
+		Branch:    "main",
+		Agents: []types.AgentIndexEntry{
+			{
+				Path:        "agents/claude-code",
+				Name:        "claude-code",
+				DisplayName: "Claude Code on OpenShift",
+				Framework:   "claude-code",
+				Description: "Deploy Claude Code on OpenShift.",
+			},
+			{
+				Path:        "agents/codex/deployment",
+				Name:        "codex",
+				DisplayName: "Codex on OpenShift",
+				Framework:   "codex",
+				Description: "Run Codex in OpenShell sandbox.",
+			},
+		},
+	}
+	indexPath := filepath.Join(tmpDir, "index.yaml")
+	writeYAML(t, indexPath, index)
+
+	catalogPath := filepath.Join(tmpDir, "catalog.yaml")
+	err := CreateAgentsCatalog(indexPath, catalogPath, "", true)
+	if err != nil {
+		t.Fatalf("CreateAgentsCatalog failed: %v", err)
+	}
+
+	data, err := os.ReadFile(catalogPath)
+	if err != nil {
+		t.Fatalf("Failed to read catalog: %v", err)
+	}
+
+	var catalog types.AgentsCatalog
+	if err := yaml.Unmarshal(data, &catalog); err != nil {
+		t.Fatalf("Failed to parse catalog: %v", err)
+	}
+
+	if catalog.Source != "Red Hat Agents" {
+		t.Errorf("expected source 'Red Hat Agents', got %q", catalog.Source)
+	}
+	if len(catalog.Agents) != 2 {
+		t.Fatalf("expected 2 agents, got %d", len(catalog.Agents))
+	}
+
+	agent := catalog.Agents[0]
+	if agent.Name != "claude-code" {
+		t.Errorf("expected name 'claude-code', got %q", agent.Name)
+	}
+	if agent.AgentType != "starter_kit" {
+		t.Errorf("expected agentType 'starter_kit', got %q", agent.AgentType)
+	}
+	if agent.RepositoryUrl != "https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/claude-code" {
+		t.Errorf("unexpected repositoryUrl: %q", agent.RepositoryUrl)
+	}
+}
+
+func TestCreateAgentsCatalogMissingIndex(t *testing.T) {
+	tmpDir := t.TempDir()
+	err := CreateAgentsCatalog(filepath.Join(tmpDir, "nonexistent.yaml"), filepath.Join(tmpDir, "catalog.yaml"), "", true)
+	if err == nil {
+		t.Fatal("expected error for missing index file")
+	}
+}
+
+func TestCreateAgentsCatalogMissingRepository(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	index := types.AgentsIndex{
+		Source: "Test",
+		Agents: []types.AgentIndexEntry{{Path: "agents/test"}},
+	}
+	indexPath := filepath.Join(tmpDir, "index.yaml")
+	writeYAML(t, indexPath, index)
+
+	err := CreateAgentsCatalog(indexPath, filepath.Join(tmpDir, "catalog.yaml"), "", true)
+	if err == nil {
+		t.Fatal("expected error for missing repository field")
+	}
+}
+
+func TestCreateAgentsCatalogEmptyIndex(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	index := types.AgentsIndex{
+		Source:     "Empty",
+		Repository: "org/repo",
+		Branch:    "main",
+		Agents:    []types.AgentIndexEntry{},
+	}
+	indexPath := filepath.Join(tmpDir, "index.yaml")
+	writeYAML(t, indexPath, index)
+
+	catalogPath := filepath.Join(tmpDir, "catalog.yaml")
+	err := CreateAgentsCatalog(indexPath, catalogPath, "", true)
+	if err != nil {
+		t.Fatalf("CreateAgentsCatalog failed: %v", err)
+	}
+
+	data, err := os.ReadFile(catalogPath)
+	if err != nil {
+		t.Fatalf("Failed to read catalog: %v", err)
+	}
+	var catalog types.AgentsCatalog
+	if err := yaml.Unmarshal(data, &catalog); err != nil {
+		t.Fatalf("Failed to parse catalog: %v", err)
+	}
+
+	if catalog.Source != "Empty" {
+		t.Errorf("expected source 'Empty', got %q", catalog.Source)
+	}
+	if len(catalog.Agents) != 0 {
+		t.Errorf("expected 0 agents, got %d", len(catalog.Agents))
+	}
+}
+
+func TestCreateAgentsCatalogDefaultBranch(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	index := types.AgentsIndex{
+		Source:     "Test",
+		Repository: "org/repo",
+		// Branch intentionally omitted — should default to "main"
+		Agents: []types.AgentIndexEntry{
+			{
+				Path:        "agents/test",
+				Name:        "test-agent",
+				Framework:   "langgraph",
+				Description: "A test agent.",
+			},
+		},
+	}
+	indexPath := filepath.Join(tmpDir, "index.yaml")
+	writeYAML(t, indexPath, index)
+
+	catalogPath := filepath.Join(tmpDir, "catalog.yaml")
+	err := CreateAgentsCatalog(indexPath, catalogPath, "", true)
+	if err != nil {
+		t.Fatalf("CreateAgentsCatalog failed: %v", err)
+	}
+
+	data, err := os.ReadFile(catalogPath)
+	if err != nil {
+		t.Fatalf("Failed to read catalog: %v", err)
+	}
+	var catalog types.AgentsCatalog
+	if err := yaml.Unmarshal(data, &catalog); err != nil {
+		t.Fatalf("Failed to parse catalog: %v", err)
+	}
+
+	if len(catalog.Agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(catalog.Agents))
+	}
+	expected := "https://github.com/org/repo/tree/main/agents/test"
+	if catalog.Agents[0].RepositoryUrl != expected {
+		t.Errorf("expected repositoryUrl %q, got %q", expected, catalog.Agents[0].RepositoryUrl)
+	}
+}
+
+func TestCreateAgentsCatalogBranchOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	index := types.AgentsIndex{
+		Source:     "Test",
+		Repository: "org/repo",
+		Branch:    "main",
+		Agents: []types.AgentIndexEntry{
+			{
+				Path:        "agents/test",
+				Name:        "test-agent",
+				Framework:   "langgraph",
+				Description: "A test agent.",
+			},
+		},
+	}
+	indexPath := filepath.Join(tmpDir, "index.yaml")
+	writeYAML(t, indexPath, index)
+
+	catalogPath := filepath.Join(tmpDir, "catalog.yaml")
+	err := CreateAgentsCatalog(indexPath, catalogPath, "release-3.5", true)
+	if err != nil {
+		t.Fatalf("CreateAgentsCatalog failed: %v", err)
+	}
+
+	data, err := os.ReadFile(catalogPath)
+	if err != nil {
+		t.Fatalf("Failed to read catalog: %v", err)
+	}
+	var catalog types.AgentsCatalog
+	if err := yaml.Unmarshal(data, &catalog); err != nil {
+		t.Fatalf("Failed to parse catalog: %v", err)
+	}
+
+	if len(catalog.Agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(catalog.Agents))
+	}
+	expected := "https://github.com/org/repo/tree/release-3.5/agents/test"
+	if catalog.Agents[0].RepositoryUrl != expected {
+		t.Errorf("expected repositoryUrl %q, got %q", expected, catalog.Agents[0].RepositoryUrl)
+	}
+}
+
+func TestCreateAgentsCatalogNonExistentBranch(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	index := types.AgentsIndex{
+		Source:     "Test",
+		Repository: "red-hat-data-services/agentic-starter-kits",
+		Branch:    "main",
+		Agents: []types.AgentIndexEntry{
+			{Path: "agents/langgraph/templates/react_agent"},
+		},
+	}
+	indexPath := filepath.Join(tmpDir, "index.yaml")
+	writeYAML(t, indexPath, index)
+
+	catalogPath := filepath.Join(tmpDir, "catalog.yaml")
+	err := CreateAgentsCatalog(indexPath, catalogPath, "this-branch-does-not-exist-xyz-12345", false)
+	if err == nil {
+		t.Fatal("expected error for non-existent branch")
+	}
+}

--- a/internal/catalog/agent_catalog_test.go
+++ b/internal/catalog/agent_catalog_test.go
@@ -102,7 +102,7 @@ func TestCreateAgentsCatalogSkipEnrichment(t *testing.T) {
 	index := types.AgentsIndex{
 		Source:     "Red Hat Agents",
 		Repository: "red-hat-data-services/agentic-starter-kits",
-		Branch:    "main",
+		Branch:     "main",
 		Agents: []types.AgentIndexEntry{
 			{
 				Path:        "agents/claude-code",
@@ -185,8 +185,8 @@ func TestCreateAgentsCatalogEmptyIndex(t *testing.T) {
 	index := types.AgentsIndex{
 		Source:     "Empty",
 		Repository: "org/repo",
-		Branch:    "main",
-		Agents:    []types.AgentIndexEntry{},
+		Branch:     "main",
+		Agents:     []types.AgentIndexEntry{},
 	}
 	indexPath := filepath.Join(tmpDir, "index.yaml")
 	writeYAML(t, indexPath, index)
@@ -263,7 +263,7 @@ func TestCreateAgentsCatalogBranchOverride(t *testing.T) {
 	index := types.AgentsIndex{
 		Source:     "Test",
 		Repository: "org/repo",
-		Branch:    "main",
+		Branch:     "main",
 		Agents: []types.AgentIndexEntry{
 			{
 				Path:        "agents/test",
@@ -306,7 +306,7 @@ func TestCreateAgentsCatalogNonExistentBranch(t *testing.T) {
 	index := types.AgentsIndex{
 		Source:     "Test",
 		Repository: "red-hat-data-services/agentic-starter-kits",
-		Branch:    "main",
+		Branch:     "main",
 		Agents: []types.AgentIndexEntry{
 			{Path: "agents/langgraph/templates/react_agent"},
 		},

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -97,6 +97,20 @@ func FetchAgentYAML(repo, branch, agentPath string) (*types.UpstreamAgentYAML, e
 		return nil, fmt.Errorf("error parsing agent.yaml from %s: %v", agentPath, err)
 	}
 
+	// Capture fields not in the struct as Extra for customProperties forwarding.
+	var raw map[string]interface{}
+	if err := yaml.Unmarshal(body, &raw); err == nil {
+		extra := make(map[string]interface{})
+		for k, v := range raw {
+			if !types.KnownUpstreamFields[k] {
+				extra[k] = v
+			}
+		}
+		if len(extra) > 0 {
+			agent.Extra = extra
+		}
+	}
+
 	return &agent, nil
 }
 

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,9 +1,11 @@
 package github
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"sync"
 	"time"
@@ -12,6 +14,8 @@ import (
 
 	"github.com/opendatahub-io/model-metadata-collection/pkg/types"
 )
+
+const maxResponseSize = 5 * 1024 * 1024 // 5 MiB safety cap for HTTP response bodies
 
 var httpClient = &http.Client{
 	Timeout: 30 * time.Second,
@@ -48,26 +52,44 @@ func buildRawURL(repo, branch, agentPath, filename string) string {
 var ErrNotFound = fmt.Errorf("not found")
 
 // ValidateBranch checks that a branch exists in the given GitHub repository.
-// Returns nil if the branch exists, an error otherwise.
-func ValidateBranch(repo, branch string) error {
-	url := fmt.Sprintf("https://api.github.com/repos/%s/branches/%s", repo, branch)
+// Returns the resolved commit SHA on success (safe for use in raw URLs even
+// when the branch name contains slashes), or an error if the branch does not exist.
+func ValidateBranch(repo, branch string) (string, error) {
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/branches/%s", repo, url.PathEscape(branch))
 
-	resp, err := doGet(url)
+	resp, err := doGet(apiURL)
 	if err != nil {
-		return fmt.Errorf("failed to validate branch %q: %v", branch, err)
+		return "", fmt.Errorf("failed to validate branch %q: %v", branch, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	// drain body so the connection can be reused
-	_, _ = io.Copy(io.Discard, resp.Body)
 
 	if resp.StatusCode == http.StatusNotFound {
-		return fmt.Errorf("branch %q does not exist in repository %q", branch, repo)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return "", fmt.Errorf("branch %q does not exist in repository %q", branch, repo)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status %d when validating branch %q in %q", resp.StatusCode, branch, repo)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return "", fmt.Errorf("unexpected status %d when validating branch %q in %q", resp.StatusCode, branch, repo)
 	}
 
-	return nil
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return "", fmt.Errorf("failed to read branch response for %q: %v", branch, err)
+	}
+
+	var branchInfo struct {
+		Commit struct {
+			SHA string `json:"sha"`
+		} `json:"commit"`
+	}
+	if err := json.Unmarshal(body, &branchInfo); err != nil {
+		return "", fmt.Errorf("failed to parse branch response for %q: %v", branch, err)
+	}
+	if branchInfo.Commit.SHA == "" {
+		return "", fmt.Errorf("branch %q in %q has no commit SHA", branch, repo)
+	}
+
+	return branchInfo.Commit.SHA, nil
 }
 
 // FetchAgentYAML fetches and parses an agent.yaml file from a GitHub repository.
@@ -87,7 +109,7 @@ func FetchAgentYAML(repo, branch, agentPath string) (*types.UpstreamAgentYAML, e
 		return nil, fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
 	if err != nil {
 		return nil, fmt.Errorf("error reading response from %s: %v", url, err)
 	}
@@ -132,7 +154,7 @@ func FetchReadme(repo, branch, agentPath string) (string, error) {
 		return "", fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
 	if err != nil {
 		return "", fmt.Errorf("error reading response from %s: %v", url, err)
 	}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -1,0 +1,127 @@
+package github
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/opendatahub-io/model-metadata-collection/pkg/types"
+)
+
+var httpClient = &http.Client{
+	Timeout: 30 * time.Second,
+}
+
+var (
+	ghToken     string
+	ghTokenOnce sync.Once
+)
+
+func getGHToken() string {
+	ghTokenOnce.Do(func() {
+		ghToken = os.Getenv("GITHUB_TOKEN")
+	})
+	return ghToken
+}
+
+func doGet(url string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if token := getGHToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return httpClient.Do(req)
+}
+
+func buildRawURL(repo, branch, agentPath, filename string) string {
+	return fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", repo, branch, agentPath, filename)
+}
+
+// ErrNotFound is returned when a requested file does not exist (HTTP 404).
+var ErrNotFound = fmt.Errorf("not found")
+
+// ValidateBranch checks that a branch exists in the given GitHub repository.
+// Returns nil if the branch exists, an error otherwise.
+func ValidateBranch(repo, branch string) error {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/branches/%s", repo, branch)
+
+	resp, err := doGet(url)
+	if err != nil {
+		return fmt.Errorf("failed to validate branch %q: %v", branch, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	// drain body so the connection can be reused
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("branch %q does not exist in repository %q", branch, repo)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d when validating branch %q in %q", resp.StatusCode, branch, repo)
+	}
+
+	return nil
+}
+
+// FetchAgentYAML fetches and parses an agent.yaml file from a GitHub repository.
+func FetchAgentYAML(repo, branch, agentPath string) (*types.UpstreamAgentYAML, error) {
+	url := buildRawURL(repo, branch, agentPath, "agent.yaml")
+
+	resp, err := doGet(url)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed for %s: %v", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response from %s: %v", url, err)
+	}
+
+	var agent types.UpstreamAgentYAML
+	if err := yaml.Unmarshal(body, &agent); err != nil {
+		return nil, fmt.Errorf("error parsing agent.yaml from %s: %v", agentPath, err)
+	}
+
+	return &agent, nil
+}
+
+// FetchReadme fetches the README.md content from a GitHub repository path.
+// Returns empty string (not error) when README is not found (404).
+func FetchReadme(repo, branch, agentPath string) (string, error) {
+	url := buildRawURL(repo, branch, agentPath, "README.md")
+
+	resp, err := doGet(url)
+	if err != nil {
+		return "", fmt.Errorf("HTTP request failed for %s: %v", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading response from %s: %v", url, err)
+	}
+
+	return string(body), nil
+}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -48,6 +49,26 @@ func buildRawURL(repo, branch, agentPath, filename string) string {
 	return fmt.Sprintf("https://raw.githubusercontent.com/%s/%s/%s/%s", repo, branch, agentPath, filename)
 }
 
+// escapeRepoPath splits an "owner/repo" string and URL-escapes each segment
+// individually so the slash between them is preserved as a path separator.
+func escapeRepoPath(repo string) string {
+	owner, name, _ := strings.Cut(repo, "/")
+	return url.PathEscape(owner) + "/" + url.PathEscape(name)
+}
+
+// readLimitedBody reads up to maxResponseSize bytes from r and returns an
+// explicit error if the response exceeds the cap (instead of silently truncating).
+func readLimitedBody(r io.Reader) ([]byte, error) {
+	body, err := io.ReadAll(io.LimitReader(r, maxResponseSize+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(body) > maxResponseSize {
+		return nil, fmt.Errorf("response exceeds max size of %d bytes", maxResponseSize)
+	}
+	return body, nil
+}
+
 // ErrNotFound is returned when a requested file does not exist (HTTP 404).
 var ErrNotFound = fmt.Errorf("not found")
 
@@ -55,7 +76,7 @@ var ErrNotFound = fmt.Errorf("not found")
 // Returns the resolved commit SHA on success (safe for use in raw URLs even
 // when the branch name contains slashes), or an error if the branch does not exist.
 func ValidateBranch(repo, branch string) (string, error) {
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/branches/%s", repo, url.PathEscape(branch))
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/branches/%s", escapeRepoPath(repo), url.PathEscape(branch))
 
 	resp, err := doGet(apiURL)
 	if err != nil {
@@ -72,7 +93,7 @@ func ValidateBranch(repo, branch string) (string, error) {
 		return "", fmt.Errorf("unexpected status %d when validating branch %q in %q", resp.StatusCode, branch, repo)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	body, err := readLimitedBody(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("failed to read branch response for %q: %v", branch, err)
 	}
@@ -109,7 +130,7 @@ func FetchAgentYAML(repo, branch, agentPath string) (*types.UpstreamAgentYAML, e
 		return nil, fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	body, err := readLimitedBody(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("error reading response from %s: %v", url, err)
 	}
@@ -154,7 +175,7 @@ func FetchReadme(repo, branch, agentPath string) (string, error) {
 		return "", fmt.Errorf("unexpected status %d from %s", resp.StatusCode, url)
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	body, err := readLimitedBody(resp.Body)
 	if err != nil {
 		return "", fmt.Errorf("error reading response from %s: %v", url, err)
 	}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,0 +1,122 @@
+package github
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRawGitHubURLConstruction(t *testing.T) {
+	tests := []struct {
+		repo       string
+		branch     string
+		agentPath  string
+		wantYAML   string
+		wantREADME string
+	}{
+		{
+			repo:       "red-hat-data-services/agentic-starter-kits",
+			branch:     "main",
+			agentPath:  "agents/langgraph/templates/react_agent",
+			wantYAML:   "https://raw.githubusercontent.com/red-hat-data-services/agentic-starter-kits/main/agents/langgraph/templates/react_agent/agent.yaml",
+			wantREADME: "https://raw.githubusercontent.com/red-hat-data-services/agentic-starter-kits/main/agents/langgraph/templates/react_agent/README.md",
+		},
+		{
+			repo:       "org/repo",
+			branch:     "develop",
+			agentPath:  "agents/test",
+			wantYAML:   "https://raw.githubusercontent.com/org/repo/develop/agents/test/agent.yaml",
+			wantREADME: "https://raw.githubusercontent.com/org/repo/develop/agents/test/README.md",
+		},
+	}
+
+	for _, tc := range tests {
+		yamlURL := buildRawURL(tc.repo, tc.branch, tc.agentPath, "agent.yaml")
+		if yamlURL != tc.wantYAML {
+			t.Errorf("YAML URL mismatch:\n  got:  %s\n  want: %s", yamlURL, tc.wantYAML)
+		}
+
+		readmeURL := buildRawURL(tc.repo, tc.branch, tc.agentPath, "README.md")
+		if readmeURL != tc.wantREADME {
+			t.Errorf("README URL mismatch:\n  got:  %s\n  want: %s", readmeURL, tc.wantREADME)
+		}
+	}
+}
+
+const testRepo = "red-hat-data-services/agentic-starter-kits"
+
+func TestValidateBranchMain(t *testing.T) {
+
+	err := ValidateBranch(testRepo, "main")
+	if err != nil {
+		t.Fatalf("expected main branch to be valid, got error: %v", err)
+	}
+}
+
+func TestValidateBranchNonExistent(t *testing.T) {
+
+	err := ValidateBranch(testRepo, "this-branch-does-not-exist-xyz-12345")
+	if err == nil {
+		t.Fatal("expected error for non-existent branch")
+	}
+}
+
+func TestFetchAgentYAMLMainBranch(t *testing.T) {
+
+	agent, err := FetchAgentYAML(testRepo, "main", "agents/langgraph/templates/react_agent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if agent.Name != "langgraph-react-agent" {
+		t.Errorf("expected name 'langgraph-react-agent', got %q", agent.Name)
+	}
+	if agent.Framework != "langgraph" {
+		t.Errorf("expected framework 'langgraph', got %q", agent.Framework)
+	}
+	if len(agent.Env.Required) == 0 {
+		t.Error("expected at least one required env var")
+	}
+}
+
+func TestFetchAgentYAMLNonExistentBranch(t *testing.T) {
+
+	_, err := FetchAgentYAML(testRepo, "this-branch-does-not-exist-xyz-12345", "agents/langgraph/templates/react_agent")
+	if err == nil {
+		t.Fatal("expected error for non-existent branch")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestFetchAgentYAMLNonExistentPath(t *testing.T) {
+
+	_, err := FetchAgentYAML(testRepo, "main", "agents/does-not-exist")
+	if err == nil {
+		t.Fatal("expected error for non-existent path")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestFetchReadmeMainBranch(t *testing.T) {
+
+	readme, err := FetchReadme(testRepo, "main", "agents/langgraph/templates/react_agent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if readme == "" {
+		t.Error("expected non-empty README content")
+	}
+}
+
+func TestFetchReadmeNonExistentBranch(t *testing.T) {
+
+	readme, err := FetchReadme(testRepo, "this-branch-does-not-exist-xyz-12345", "agents/langgraph/templates/react_agent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if readme != "" {
+		t.Error("expected empty README for non-existent branch")
+	}
+}

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -45,16 +45,20 @@ func TestRawGitHubURLConstruction(t *testing.T) {
 const testRepo = "red-hat-data-services/agentic-starter-kits"
 
 func TestValidateBranchMain(t *testing.T) {
-
-	err := ValidateBranch(testRepo, "main")
+	sha, err := ValidateBranch(testRepo, "main")
 	if err != nil {
 		t.Fatalf("expected main branch to be valid, got error: %v", err)
+	}
+	if sha == "" {
+		t.Fatal("expected non-empty commit SHA")
+	}
+	if len(sha) != 40 {
+		t.Errorf("expected 40-char SHA, got %d chars: %s", len(sha), sha)
 	}
 }
 
 func TestValidateBranchNonExistent(t *testing.T) {
-
-	err := ValidateBranch(testRepo, "this-branch-does-not-exist-xyz-12345")
+	_, err := ValidateBranch(testRepo, "this-branch-does-not-exist-xyz-12345")
 	if err == nil {
 		t.Fatal("expected error for non-existent branch")
 	}

--- a/pkg/types/agent.go
+++ b/pkg/types/agent.go
@@ -14,9 +14,9 @@ type AgentIndexEntry struct {
 // AgentsIndex represents the agents index file structure.
 type AgentsIndex struct {
 	Source     string            `yaml:"source"`
-	Repository string           `yaml:"repository"`
-	Branch    string             `yaml:"branch"`
-	Agents    []AgentIndexEntry  `yaml:"agents"`
+	Repository string            `yaml:"repository"`
+	Branch     string            `yaml:"branch"`
+	Agents     []AgentIndexEntry `yaml:"agents"`
 }
 
 // UpstreamAgentYAML represents the known fields from agent.yaml in the

--- a/pkg/types/agent.go
+++ b/pkg/types/agent.go
@@ -19,7 +19,9 @@ type AgentsIndex struct {
 	Agents    []AgentIndexEntry  `yaml:"agents"`
 }
 
-// UpstreamAgentYAML represents the agent.yaml format in the agentic-starter-kits repo.
+// UpstreamAgentYAML represents the known fields from agent.yaml in the
+// agentic-starter-kits repo. Any fields not listed here are captured in
+// Extra and forwarded as customProperties in the catalog output.
 type UpstreamAgentYAML struct {
 	Name        string `yaml:"name"`
 	DisplayName string `yaml:"displayName"`
@@ -29,6 +31,14 @@ type UpstreamAgentYAML struct {
 		Required []string `yaml:"required"`
 		Optional []string `yaml:"optional"`
 	} `yaml:"env"`
+	Extra map[string]interface{} `yaml:"-"`
+}
+
+// KnownUpstreamFields lists the agent.yaml keys that are handled explicitly
+// and should NOT be forwarded into customProperties.
+var KnownUpstreamFields = map[string]bool{
+	"name": true, "displayName": true, "framework": true,
+	"description": true, "env": true,
 }
 
 // AgentEnvVar represents an environment variable for an agent.
@@ -52,11 +62,8 @@ type AgentMetadata struct {
 	Description              string                   `yaml:"description"`
 	Readme                   string                   `yaml:"readme,omitempty"`
 	RepositoryUrl            string                   `yaml:"repositoryUrl,omitempty"`
-	PublishedDate            string                   `yaml:"publishedDate,omitempty"`
 	Framework                string                   `yaml:"framework"`
-	AgentType                string                   `yaml:"agentType"`
-	Tags                     []string                 `yaml:"tags,omitempty"`
-	Models                   []string                 `yaml:"models,omitempty"`
+	Labels                   []string                 `yaml:"labels,omitempty"`
 	Logo                     string                   `yaml:"logo,omitempty"`
 	Env                      []AgentEnvVar            `yaml:"env,omitempty"`
 	Artifacts                []AgentArtifact          `yaml:"artifacts,omitempty"`

--- a/pkg/types/agent.go
+++ b/pkg/types/agent.go
@@ -1,0 +1,72 @@
+package types
+
+// AgentIndexEntry represents an entry in the agents index file.
+// For agents with agent.yaml upstream, only Path is needed — metadata is fetched.
+// For deployment-only agents without agent.yaml, metadata fields are provided inline.
+type AgentIndexEntry struct {
+	Path        string `yaml:"path"`
+	Name        string `yaml:"name,omitempty"`
+	DisplayName string `yaml:"displayName,omitempty"`
+	Framework   string `yaml:"framework,omitempty"`
+	Description string `yaml:"description,omitempty"`
+}
+
+// AgentsIndex represents the agents index file structure.
+type AgentsIndex struct {
+	Source     string            `yaml:"source"`
+	Repository string           `yaml:"repository"`
+	Branch    string             `yaml:"branch"`
+	Agents    []AgentIndexEntry  `yaml:"agents"`
+}
+
+// UpstreamAgentYAML represents the agent.yaml format in the agentic-starter-kits repo.
+type UpstreamAgentYAML struct {
+	Name        string `yaml:"name"`
+	DisplayName string `yaml:"displayName"`
+	Framework   string `yaml:"framework"`
+	Description string `yaml:"description"`
+	Env         struct {
+		Required []string `yaml:"required"`
+		Optional []string `yaml:"optional"`
+	} `yaml:"env"`
+}
+
+// AgentEnvVar represents an environment variable for an agent.
+type AgentEnvVar struct {
+	Name     string `yaml:"name"`
+	Required bool   `yaml:"required"`
+}
+
+// AgentArtifact represents a container artifact for an agent.
+type AgentArtifact struct {
+	URI                      string `yaml:"uri"`
+	CreateTimeSinceEpoch     string `yaml:"createTimeSinceEpoch,omitempty"`
+	LastUpdateTimeSinceEpoch string `yaml:"lastUpdateTimeSinceEpoch,omitempty"`
+}
+
+// AgentMetadata represents the full metadata for a single agent in the catalog.
+type AgentMetadata struct {
+	Name                     string                   `yaml:"name"`
+	ExternalID               string                   `yaml:"externalId,omitempty"`
+	DisplayName              string                   `yaml:"displayName"`
+	Description              string                   `yaml:"description"`
+	Readme                   string                   `yaml:"readme,omitempty"`
+	RepositoryUrl            string                   `yaml:"repositoryUrl,omitempty"`
+	PublishedDate            string                   `yaml:"publishedDate,omitempty"`
+	Framework                string                   `yaml:"framework"`
+	AgentType                string                   `yaml:"agentType"`
+	Tags                     []string                 `yaml:"tags,omitempty"`
+	Models                   []string                 `yaml:"models,omitempty"`
+	Logo                     string                   `yaml:"logo,omitempty"`
+	Env                      []AgentEnvVar            `yaml:"env,omitempty"`
+	Artifacts                []AgentArtifact          `yaml:"artifacts,omitempty"`
+	CustomProperties         map[string]MetadataValue `yaml:"customProperties,omitempty"`
+	CreateTimeSinceEpoch     string                   `yaml:"createTimeSinceEpoch,omitempty"`
+	LastUpdateTimeSinceEpoch string                   `yaml:"lastUpdateTimeSinceEpoch,omitempty"`
+}
+
+// AgentsCatalog represents the aggregated catalog of agents.
+type AgentsCatalog struct {
+	Source string          `yaml:"source"`
+	Agents []AgentMetadata `yaml:"agents"`
+}


### PR DESCRIPTION
## Summary

- Add end-to-end pipeline that fetches agent metadata from the [agentic-starter-kits](https://github.com/red-hat-data-services/agentic-starter-kits) GitHub repo, transforms it into catalog format, and produces an aggregated `agents-catalog.yaml`
- New GitHub client (`internal/github/`) fetches `agent.yaml` and `README.md` for each agent, with `GITHUB_TOKEN` auth support and branch validation
- Env vars are transformed from upstream format (`env.required`/`env.optional` string lists) into the catalog format (`[{name, required}]`)
- Deployment-only agents (claude-code, openclaw, codex, opencode) without `agent.yaml` use inline metadata from the index file
- Unknown upstream fields are automatically forwarded as `customProperties` (e.g. langflow's `deploymentModel`)
- Schema aligned with kubeflow/hub#2907 (no `agentType`, `publishedDate`, `models`; `tags` renamed to `labels`)
- CLI flags: `--agent-index`, `--agent-catalog-output`, `--agent-branch`, `--skip-agent-enrichment`
- Makefile target: `make process-agents`

## Test plan

- [x] `make build` compiles
- [x] `make test` — all existing and new tests pass
- [x] `make process-agents` — produces `data/redhat-agents-catalog.yaml` with 15 agents
- [x] Verified output loads correctly in kubeflow/hub catalog service (main branch, post #2907)
- [x] All 15 agents visible via `GET /api/agent_catalog/v1alpha1/agents`
- [x] `customProperties` forwarding verified (langflow `deploymentModel`)
- [x] Source shows `status=available` via `GET /sources?assetType=agents`
- [x] Branch validation rejects non-existent branches with clear error
- [x] `--skip-agent-enrichment` produces catalog from index overrides only (offline mode)

Ref: RHOAIENG-70682

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “agents catalog” generation to the standard pipeline alongside existing model and MCP outputs.
  * Introduced a new agents index and new configurable input/output paths for catalog creation.
  * Extended the CLI with agents index input, catalog output, GitHub branch override, and an option to skip agent enrichment.
* **Documentation**
  * Updated CLI help text with examples for generating the agents catalog (with and without GitHub enrichment).
* **Bug Fixes**
  * Improved robustness for remote metadata fetching with clearer missing-index handling and branch validation.
* **Tests**
  * Added coverage for catalog creation behavior, overrides/defaults, and GitHub fetch/enrichment paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->