### PR TITLE
feat(catalog): add readmePath override and regenerate agent catalog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY data/partner-mcp-servers-catalog.yaml /app/data/
 COPY data/partner-mcp-servers-index.yaml /app/data/
 COPY data/community-mcp-servers-catalog.yaml /app/data/
 COPY data/community-mcp-servers-index.yaml /app/data/
+COPY data/redhat-agents-catalog.yaml /app/data/
 
 # Copy sample data for benchmarks
 COPY sample-data/ /app/benchmarks/
@@ -29,6 +30,7 @@ RUN chmod 644 /app/data/models-catalog.yaml /app/data/models-index.yaml && \
     chmod 644 /app/data/redhat-mcp-servers-catalog.yaml /app/data/redhat-mcp-servers-index.yaml && \
     chmod 644 /app/data/partner-mcp-servers-catalog.yaml /app/data/partner-mcp-servers-index.yaml && \
     chmod 644 /app/data/community-mcp-servers-catalog.yaml /app/data/community-mcp-servers-index.yaml && \
+    chmod 644 /app/data/redhat-agents-catalog.yaml && \
     chmod -R 755 /app/benchmarks && \
     chmod 644 /app/benchmarks/manifest.json && \
     /bin/sh -c 'for f in /app/benchmarks/models/*/*/*/*; do [ -f "$f" ] && chmod 644 "$f" || true; done'

--- a/data/redhat-agents-catalog.yaml
+++ b/data/redhat-agents-catalog.yaml
@@ -283,6 +283,10 @@ agents:
         - [Ollama Documentation](https://ollama.com/docs)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/langgraph/templates/react_agent
       framework: langgraph
+      labels:
+        - tool-calling
+        - react
+      logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiMxQzNDM0MiLz4KICA8cGF0aCBkPSJNMzIgMTJjLTMgMC01LjUgMS41LTcgNGwtMiAzLjVjLTEgMS44LS41IDQgMSA1LjJsMS41IDEuMmMtLjUgMS41LS4yIDMuMi44IDQuNWwtNCA3Yy0xLjUgMi42LS41IDYgMiA3LjVsNSAzYzIuNSAxLjUgNS41LjggNy4yLTEuNWw2LTguNWMxLjUtMiAxLjUtNC44IDAtNi44bC0yLTIuOGMuOC0xLjUuOC0zLjUtLjItNUwzOCAxOWMtMS0xLjUtMS0zLjUgMC01LS41LTEuMi0yLjUtMi00LTJoLTJ6IiBmaWxsPSIjNEFERTgwIi8+CiAgPGNpcmNsZSBjeD0iMzAiIGN5PSIyMCIgcj0iMS41IiBmaWxsPSIjMUMzQzNDIi8+CiAgPHBhdGggZD0iTTIyIDQwbDMgNmMuNSAxIDEuOCAxLjUgMi44IDFsMi0xIiBzdHJva2U9IiM0QURFODAiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+Cjwvc3ZnPg==
       env:
         - name: API_KEY
           required: true
@@ -300,6 +304,9 @@ agents:
           required: false
         - name: AUTH_ALLOWED_SERVICEACCOUNTS
           required: false
+      templates:
+        - name: agent.yaml
+          content: '{"description":"General-purpose ReAct agent built with LangGraph using a reason-and-act loop with external tools.","displayName":"LangGraph ReAct Agent","env":{"optional":["PORT","CONTAINER_IMAGE","AUTH_ENABLED","AUTH_AUDIENCE","AUTH_ALLOWED_SERVICEACCOUNTS"],"required":["API_KEY","BASE_URL","MODEL_ID"]},"framework":"langgraph","labels":["tool-calling","react"],"logo":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiMxQzNDM0MiLz4KICA8cGF0aCBkPSJNMzIgMTJjLTMgMC01LjUgMS41LTcgNGwtMiAzLjVjLTEgMS44LS41IDQgMSA1LjJsMS41IDEuMmMtLjUgMS41LS4yIDMuMi44IDQuNWwtNCA3Yy0xLjUgMi42LS41IDYgMiA3LjVsNSAzYzIuNSAxLjUgNS41LjggNy4yLTEuNWw2LTguNWMxLjUtMiAxLjUtNC44IDAtNi44bC0yLTIuOGMuOC0xLjUuOC0zLjUtLjItNUwzOCAxOWMtMS0xLjUtMS0zLjUgMC01LS41LTEuMi0yLjUtMi00LTJoLTJ6IiBmaWxsPSIjNEFERTgwIi8+CiAgPGNpcmNsZSBjeD0iMzAiIGN5PSIyMCIgcj0iMS41IiBmaWxsPSIjMUMzQzNDIi8+CiAgPHBhdGggZD0iTTIyIDQwbDMgNmMuNSAxIDEuOCAxLjUgMi44IDFsMi0xIiBzdHJva2U9IiM0QURFODAiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+Cjwvc3ZnPg==","name":"langgraph-react-agent"}'
     - name: langgraph-agentic-rag
       displayName: LangGraph Agentic RAG Agent
       description: RAG agent that indexes documents in a vector store (Milvus) and retrieves relevant chunks to augment the LLM's answers.
@@ -706,6 +713,11 @@ agents:
         - [Milvus Documentation](https://milvus.io/docs)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/langgraph/templates/agentic_rag
       framework: langgraph
+      labels:
+        - rag
+        - tool-calling
+        - vector-store
+      logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiMxQzNDM0MiLz4KICA8cGF0aCBkPSJNMzIgMTJjLTMgMC01LjUgMS41LTcgNGwtMiAzLjVjLTEgMS44LS41IDQgMSA1LjJsMS41IDEuMmMtLjUgMS41LS4yIDMuMi44IDQuNWwtNCA3Yy0xLjUgMi42LS41IDYgMiA3LjVsNSAzYzIuNSAxLjUgNS41LjggNy4yLTEuNWw2LTguNWMxLjUtMiAxLjUtNC44IDAtNi44bC0yLTIuOGMuOC0xLjUuOC0zLjUtLjItNUwzOCAxOWMtMS0xLjUtMS0zLjUgMC01LS41LTEuMi0yLjUtMi00LTJoLTJ6IiBmaWxsPSIjNEFERTgwIi8+CiAgPGNpcmNsZSBjeD0iMzAiIGN5PSIyMCIgcj0iMS41IiBmaWxsPSIjMUMzQzNDIi8+CiAgPHBhdGggZD0iTTIyIDQwbDMgNmMuNSAxIDEuOCAxLjUgMi44IDFsMi0xIiBzdHJva2U9IiM0QURFODAiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+Cjwvc3ZnPg==
       env:
         - name: API_KEY
           required: true
@@ -729,6 +741,9 @@ agents:
           required: false
         - name: DOCS_TO_LOAD
           required: false
+      templates:
+        - name: agent.yaml
+          content: '{"description":"RAG agent that indexes documents in a vector store (Milvus) and retrieves relevant chunks to augment the LLM''s answers.","displayName":"LangGraph Agentic RAG Agent","env":{"optional":["PORT","CONTAINER_IMAGE","EMBEDDING_MODEL","EMBEDDING_DIMENSION","VECTOR_STORE_ID","VECTOR_STORE_PROVIDER","VECTOR_STORE_PATH","DOCS_TO_LOAD"],"required":["API_KEY","BASE_URL","MODEL_ID"]},"framework":"langgraph","labels":["rag","tool-calling","vector-store"],"logo":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiMxQzNDM0MiLz4KICA8cGF0aCBkPSJNMzIgMTJjLTMgMC01LjUgMS41LTcgNGwtMiAzLjVjLTEgMS44LS41IDQgMSA1LjJsMS41IDEuMmMtLjUgMS41LS4yIDMuMi44IDQuNWwtNCA3Yy0xLjUgMi42LS41IDYgMiA3LjVsNSAzYzIuNSAxLjUgNS41LjggNy4yLTEuNWw2LTguNWMxLjUtMiAxLjUtNC44IDAtNi44bC0yLTIuOGMuOC0xLjUuOC0zLjUtLjItNUwzOCAxOWMtMS0xLjUtMS0zLjUgMC01LS41LTEuMi0yLjUtMi00LTJoLTJ6IiBmaWxsPSIjNEFERTgwIi8+CiAgPGNpcmNsZSBjeD0iMzAiIGN5PSIyMCIgcj0iMS41IiBmaWxsPSIjMUMzQzNDIi8+CiAgPHBhdGggZD0iTTIyIDQwbDMgNmMuNSAxIDEuOCAxLjUgMi44IDFsMi0xIiBzdHJva2U9IiM0QURFODAiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+Cjwvc3ZnPg==","name":"langgraph-agentic-rag"}'
     - name: langgraph-db-memory-agent
       displayName: LangGraph ReAct Agent with Database Memory
       description: ReAct agent with PostgreSQL-based conversation memory for persistent, thread-based chat history.
@@ -1196,6 +1211,12 @@ agents:
         - [PostgreSQL Documentation](https://www.postgresql.org/docs/)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/langgraph/templates/react_with_database_memory
       framework: langgraph
+      labels:
+        - tool-calling
+        - react
+        - memory
+        - database
+      logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiMxQzNDM0MiLz4KICA8cGF0aCBkPSJNMzIgMTJjLTMgMC01LjUgMS41LTcgNGwtMiAzLjVjLTEgMS44LS41IDQgMSA1LjJsMS41IDEuMmMtLjUgMS41LS4yIDMuMi44IDQuNWwtNCA3Yy0xLjUgMi42LS41IDYgMiA3LjVsNSAzYzIuNSAxLjUgNS41LjggNy4yLTEuNWw2LTguNWMxLjUtMiAxLjUtNC44IDAtNi44bC0yLTIuOGMuOC0xLjUuOC0zLjUtLjItNUwzOCAxOWMtMS0xLjUtMS0zLjUgMC01LS41LTEuMi0yLjUtMi00LTJoLTJ6IiBmaWxsPSIjNEFERTgwIi8+CiAgPGNpcmNsZSBjeD0iMzAiIGN5PSIyMCIgcj0iMS41IiBmaWxsPSIjMUMzQzNDIi8+CiAgPHBhdGggZD0iTTIyIDQwbDMgNmMuNSAxIDEuOCAxLjUgMi44IDFsMi0xIiBzdHJva2U9IiM0QURFODAiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+Cjwvc3ZnPg==
       env:
         - name: API_KEY
           required: true
@@ -1217,6 +1238,9 @@ agents:
           required: false
         - name: CONTAINER_IMAGE
           required: false
+      templates:
+        - name: agent.yaml
+          content: '{"description":"ReAct agent with PostgreSQL-based conversation memory for persistent, thread-based chat history.","displayName":"LangGraph ReAct Agent with Database Memory","env":{"optional":["PORT","CONTAINER_IMAGE"],"required":["API_KEY","BASE_URL","MODEL_ID","POSTGRES_HOST","POSTGRES_PORT","POSTGRES_DB","POSTGRES_USER","POSTGRES_PASSWORD"]},"framework":"langgraph","labels":["tool-calling","react","memory","database"],"logo":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiMxQzNDM0MiLz4KICA8cGF0aCBkPSJNMzIgMTJjLTMgMC01LjUgMS41LTcgNGwtMiAzLjVjLTEgMS44LS41IDQgMSA1LjJsMS41IDEuMmMtLjUgMS41LS4yIDMuMi44IDQuNWwtNCA3Yy0xLjUgMi42LS41IDYgMiA3LjVsNSAzYzIuNSAxLjUgNS41LjggNy4yLTEuNWw2LTguNWMxLjUtMiAxLjUtNC44IDAtNi44bC0yLTIuOGMuOC0xLjUuOC0zLjUtLjItNUwzOCAxOWMtMS0xLjUtMS0zLjUgMC01LS41LTEuMi0yLjUtMi00LTJoLTJ6IiBmaWxsPSIjNEFERTgwIi8+CiAgPGNpcmNsZSBjeD0iMzAiIGN5PSIyMCIgcj0iMS41IiBmaWxsPSIjMUMzQzNDIi8+CiAgPHBhdGggZD0iTTIyIDQwbDMgNmMuNSAxIDEuOCAxLjUgMi44IDFsMi0xIiBzdHJva2U9IiM0QURFODAiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+Cjwvc3ZnPg==","name":"langgraph-db-memory-agent"}'
     - name: langgraph-hitl-agent
       displayName: LangGraph Human-in-the-Loop Agent
       description: LangGraph agent with human approval workflow that pauses for review before executing sensitive tools.
@@ -1715,6 +1739,10 @@ agents:
         - [Ollama Documentation](https://ollama.com/docs)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/langgraph/templates/human_in_the_loop
       framework: langgraph
+      labels:
+        - tool-calling
+        - human-in-the-loop
+      logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiMxQzNDM0MiLz4KICA8cGF0aCBkPSJNMzIgMTJjLTMgMC01LjUgMS41LTcgNGwtMiAzLjVjLTEgMS44LS41IDQgMSA1LjJsMS41IDEuMmMtLjUgMS41LS4yIDMuMi44IDQuNWwtNCA3Yy0xLjUgMi42LS41IDYgMiA3LjVsNSAzYzIuNSAxLjUgNS41LjggNy4yLTEuNWw2LTguNWMxLjUtMiAxLjUtNC44IDAtNi44bC0yLTIuOGMuOC0xLjUuOC0zLjUtLjItNUwzOCAxOWMtMS0xLjUtMS0zLjUgMC01LS41LTEuMi0yLjUtMi00LTJoLTJ6IiBmaWxsPSIjNEFERTgwIi8+CiAgPGNpcmNsZSBjeD0iMzAiIGN5PSIyMCIgcj0iMS41IiBmaWxsPSIjMUMzQzNDIi8+CiAgPHBhdGggZD0iTTIyIDQwbDMgNmMuNSAxIDEuOCAxLjUgMi44IDFsMi0xIiBzdHJva2U9IiM0QURFODAiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+Cjwvc3ZnPg==
       env:
         - name: API_KEY
           required: true
@@ -1726,6 +1754,9 @@ agents:
           required: false
         - name: CONTAINER_IMAGE
           required: false
+      templates:
+        - name: agent.yaml
+          content: '{"description":"LangGraph agent with human approval workflow that pauses for review before executing sensitive tools.","displayName":"LangGraph Human-in-the-Loop Agent","env":{"optional":["PORT","CONTAINER_IMAGE"],"required":["API_KEY","BASE_URL","MODEL_ID"]},"framework":"langgraph","labels":["tool-calling","human-in-the-loop"],"logo":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiMxQzNDM0MiLz4KICA8cGF0aCBkPSJNMzIgMTJjLTMgMC01LjUgMS41LTcgNGwtMiAzLjVjLTEgMS44LS41IDQgMSA1LjJsMS41IDEuMmMtLjUgMS41LS4yIDMuMi44IDQuNWwtNCA3Yy0xLjUgMi42LS41IDYgMiA3LjVsNSAzYzIuNSAxLjUgNS41LjggNy4yLTEuNWw2LTguNWMxLjUtMiAxLjUtNC44IDAtNi44bC0yLTIuOGMuOC0xLjUuOC0zLjUtLjItNUwzOCAxOWMtMS0xLjUtMS0zLjUgMC01LS41LTEuMi0yLjUtMi00LTJoLTJ6IiBmaWxsPSIjNEFERTgwIi8+CiAgPGNpcmNsZSBjeD0iMzAiIGN5PSIyMCIgcj0iMS41IiBmaWxsPSIjMUMzQzNDIi8+CiAgPHBhdGggZD0iTTIyIDQwbDMgNmMuNSAxIDEuOCAxLjUgMi44IDFsMi0xIiBzdHJva2U9IiM0QURFODAiIHN0cm9rZS13aWR0aD0iMiIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+Cjwvc3ZnPg==","name":"langgraph-hitl-agent"}'
     - name: crewai-websearch-agent
       displayName: CrewAI WebSearch Agent
       description: Web search agent built with CrewAI using a ReAct-style crew with a web search tool to answer user questions.
@@ -2068,6 +2099,10 @@ agents:
         - [CrewAI Tools](https://docs.crewai.com/concepts/tools)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/crewai/templates/websearch_agent
       framework: crewai
+      labels:
+        - web-search
+        - tool-calling
+      logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiNGRjVBNTAiLz4KICA8Y2lyY2xlIGN4PSIyMiIgY3k9IjIyIiByPSI1IiBmaWxsPSJ3aGl0ZSIvPgogIDxjaXJjbGUgY3g9IjQyIiBjeT0iMjIiIHI9IjUiIGZpbGw9IndoaXRlIi8+CiAgPGNpcmNsZSBjeD0iMzIiIGN5PSIyMCIgcj0iNiIgZmlsbD0id2hpdGUiLz4KICA8cGF0aCBkPSJNMzIgMjhjLTYgMC0xMSAzLTEzIDh2NGgyNnYtNGMtMi01LTctOC0xMy04eiIgZmlsbD0id2hpdGUiLz4KICA8cGF0aCBkPSJNMjIgMjljLTUgMC05IDIuNS0xMSA2LjVWNDBoMTB2LTRjMC0yLjUuOC00LjggMi02LjUtLjMtLjMtLjYtLjQtMS0uNXoiIGZpbGw9IndoaXRlIiBvcGFjaXR5PSIuNyIvPgogIDxwYXRoIGQ9Ik00MiAyOWM1IDAgOSAyLjUgMTEgNi41VjQwSDQzdi00YzAtMi41LS44LTQuOC0yLTYuNS4zLS4zLjYtLjQgMS0uNXoiIGZpbGw9IndoaXRlIiBvcGFjaXR5PSIuNyIvPgo8L3N2Zz4=
       env:
         - name: API_KEY
           required: true
@@ -2079,6 +2114,9 @@ agents:
           required: false
         - name: CONTAINER_IMAGE
           required: false
+      templates:
+        - name: agent.yaml
+          content: '{"description":"Web search agent built with CrewAI using a ReAct-style crew with a web search tool to answer user questions.","displayName":"CrewAI WebSearch Agent","env":{"optional":["PORT","CONTAINER_IMAGE"],"required":["API_KEY","BASE_URL","MODEL_ID"]},"framework":"crewai","labels":["web-search","tool-calling"],"logo":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiNGRjVBNTAiLz4KICA8Y2lyY2xlIGN4PSIyMiIgY3k9IjIyIiByPSI1IiBmaWxsPSJ3aGl0ZSIvPgogIDxjaXJjbGUgY3g9IjQyIiBjeT0iMjIiIHI9IjUiIGZpbGw9IndoaXRlIi8+CiAgPGNpcmNsZSBjeD0iMzIiIGN5PSIyMCIgcj0iNiIgZmlsbD0id2hpdGUiLz4KICA8cGF0aCBkPSJNMzIgMjhjLTYgMC0xMSAzLTEzIDh2NGgyNnYtNGMtMi01LTctOC0xMy04eiIgZmlsbD0id2hpdGUiLz4KICA8cGF0aCBkPSJNMjIgMjljLTUgMC05IDIuNS0xMSA2LjVWNDBoMTB2LTRjMC0yLjUuOC00LjggMi02LjUtLjMtLjMtLjYtLjQtMS0uNXoiIGZpbGw9IndoaXRlIiBvcGFjaXR5PSIuNyIvPgogIDxwYXRoIGQ9Ik00MiAyOWM1IDAgOSAyLjUgMTEgNi41VjQwSDQzdi00YzAtMi41LS44LTQuOC0yLTYuNS4zLS4zLjYtLjQgMS0uNXoiIGZpbGw9IndoaXRlIiBvcGFjaXR5PSIuNyIvPgo8L3N2Zz4=","name":"crewai-websearch-agent"}'
     - name: llamaindex-websearch-agent
       displayName: LlamaIndex WebSearch Agent
       description: Agent built on LlamaIndex that uses a web search tool to query the internet and augment answers.
@@ -2397,6 +2435,10 @@ agents:
         - [Ollama Documentation](https://ollama.com/docs)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/llamaindex/templates/websearch_agent
       framework: llamaindex
+      labels:
+        - web-search
+        - tool-calling
+      logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiM4QjVDRjYiLz4KICA8cGF0aCBkPSJNMjQgNDhWMzBjMC00IDItNy41IDUtOS41bDMtMlYxNGwtMS0zIDItMSAzIDIgMSAzdjMuNWwyIDEuNWMzIDIuMiA1IDUuOCA1IDEwVjQ4IiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgZmlsbD0ibm9uZSIvPgogIDxjaXJjbGUgY3g9IjMwIiBjeT0iMjQiIHI9IjEuNSIgZmlsbD0id2hpdGUiLz4KICA8bGluZSB4MT0iMjQiIHkxPSI0OCIgeDI9IjI0IiB5Mj0iNDQiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMyIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+CiAgPGxpbmUgeDE9IjMwIiB5MT0iNDgiIHgyPSIzMCIgeTI9IjQ0IiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgogIDxsaW5lIHgxPSIzNiIgeTE9IjQ4IiB4Mj0iMzYiIHkyPSI0NCIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIzIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICA8bGluZSB4MT0iNDIiIHkxPSI0OCIgeDI9IjQyIiB5Mj0iNDQiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMyIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+Cjwvc3ZnPg==
       env:
         - name: API_KEY
           required: true
@@ -2408,6 +2450,9 @@ agents:
           required: false
         - name: CONTAINER_IMAGE
           required: false
+      templates:
+        - name: agent.yaml
+          content: '{"description":"Agent built on LlamaIndex that uses a web search tool to query the internet and augment answers.","displayName":"LlamaIndex WebSearch Agent","env":{"optional":["PORT","CONTAINER_IMAGE"],"required":["API_KEY","BASE_URL","MODEL_ID"]},"framework":"llamaindex","labels":["web-search","tool-calling"],"logo":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiM4QjVDRjYiLz4KICA8cGF0aCBkPSJNMjQgNDhWMzBjMC00IDItNy41IDUtOS41bDMtMlYxNGwtMS0zIDItMSAzIDIgMSAzdjMuNWwyIDEuNWMzIDIuMiA1IDUuOCA1IDEwVjQ4IiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIgZmlsbD0ibm9uZSIvPgogIDxjaXJjbGUgY3g9IjMwIiBjeT0iMjQiIHI9IjEuNSIgZmlsbD0id2hpdGUiLz4KICA8bGluZSB4MT0iMjQiIHkxPSI0OCIgeDI9IjI0IiB5Mj0iNDQiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMyIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+CiAgPGxpbmUgeDE9IjMwIiB5MT0iNDgiIHgyPSIzMCIgeTI9IjQ0IiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPgogIDxsaW5lIHgxPSIzNiIgeTE9IjQ4IiB4Mj0iMzYiIHkyPSI0NCIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIzIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz4KICA8bGluZSB4MT0iNDIiIHkxPSI0OCIgeDI9IjQyIiB5Mj0iNDQiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMyIgc3Ryb2tlLWxpbmVjYXA9InJvdW5kIi8+Cjwvc3ZnPg==","name":"llamaindex-websearch-agent"}'
     - name: openai-responses-agent
       displayName: OpenAI Responses Agent
       description: 'Minimal agent with no framework: only the OpenAI Python client and an Action/Observation loop with tools.'
@@ -2687,6 +2732,10 @@ agents:
         - [OpenAI Responses API](https://developers.openai.com/api/reference/resources/responses/methods/create)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/vanilla_python/templates/openai_responses_agent
       framework: vanilla_python
+      labels:
+        - tool-calling
+        - no-framework
+      logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiMzNzc2QUIiLz4KICA8cGF0aCBkPSJNMzEuNSAxNGMtNyAwLTYuNSAzLTYuNSAzdjMuMmg2LjZ2MUgyMS4yUzE0IDIwLjUgMTQgMjcuOHMzLjIgNyAzLjIgN2g0LjN2LTMuNHMtLjItMy42IDMuNS0zLjZoNi4xczMuNC4xIDMuNC0zLjNWMTguMlMzNSAxNCAzMS41IDE0em0tMy42IDIuNGMuNyAwIDEuMi41IDEuMiAxLjJzLS41IDEuMi0xLjIgMS4yLTEuMi0uNS0xLjItMS4yLjUtMS4yIDEuMi0xLjJ6IiBmaWxsPSJ3aGl0ZSIvPgogIDxwYXRoIGQ9Ik0zMi41IDUwYzcgMCA2LjUtMyA2LjUtM3YtMy4yaC02LjZ2LTFoMTAuNFM1MCA0My41IDUwIDM2LjJzLTMuMi03LTMuMi03aC00LjN2My40cy4yIDMuNi0zLjUgMy42aC02LjFzLTMuNC0uMS0zLjQgMy4zdjYuM1MyOSA1MCAzMi41IDUwem0zLjYtMi40Yy0uNyAwLTEuMi0uNS0xLjItMS4ycy41LTEuMiAxLjItMS4yIDEuMi41IDEuMiAxLjItLjUgMS4yLTEuMiAxLjJ6IiBmaWxsPSJ3aGl0ZSIgb3BhY2l0eT0iLjc1Ii8+Cjwvc3ZnPg==
       env:
         - name: API_KEY
           required: true
@@ -2698,6 +2747,9 @@ agents:
           required: false
         - name: CONTAINER_IMAGE
           required: false
+      templates:
+        - name: agent.yaml
+          content: '{"description":"Minimal agent with no framework: only the OpenAI Python client and an Action/Observation loop with tools.","displayName":"OpenAI Responses Agent","env":{"optional":["PORT","CONTAINER_IMAGE"],"required":["API_KEY","BASE_URL","MODEL_ID"]},"framework":"vanilla_python","labels":["tool-calling","no-framework"],"logo":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiMzNzc2QUIiLz4KICA8cGF0aCBkPSJNMzEuNSAxNGMtNyAwLTYuNSAzLTYuNSAzdjMuMmg2LjZ2MUgyMS4yUzE0IDIwLjUgMTQgMjcuOHMzLjIgNyAzLjIgN2g0LjN2LTMuNHMtLjItMy42IDMuNS0zLjZoNi4xczMuNC4xIDMuNC0zLjNWMTguMlMzNSAxNCAzMS41IDE0em0tMy42IDIuNGMuNyAwIDEuMi41IDEuMiAxLjJzLS41IDEuMi0xLjIgMS4yLTEuMi0uNS0xLjItMS4yLjUtMS4yIDEuMi0xLjJ6IiBmaWxsPSJ3aGl0ZSIvPgogIDxwYXRoIGQ9Ik0zMi41IDUwYzcgMCA2LjUtMyA2LjUtM3YtMy4yaC02LjZ2LTFoMTAuNFM1MCA0My41IDUwIDM2LjJzLTMuMi03LTMuMi03aC00LjN2My40cy4yIDMuNi0zLjUgMy42aC02LjFzLTMuNC0uMS0zLjQgMy4zdjYuM1MyOSA1MCAzMi41IDUwem0zLjYtMi40Yy0uNyAwLTEuMi0uNS0xLjItMS4ycy41LTEuMiAxLjItMS4yIDEuMi41IDEuMiAxLjItLjUgMS4yLTEuMiAxLjJ6IiBmaWxsPSJ3aGl0ZSIgb3BhY2l0eT0iLjc1Ii8+Cjwvc3ZnPg==","name":"openai-responses-agent"}'
     - name: autogen-mcp-agent
       displayName: AutoGen Agent (MCP)
       description: AutoGen-based agent with MCP tools over SSE. Connects to an MCP server, loads tools dynamically, and answers user questions via an OpenAI-compatible API.
@@ -3157,6 +3209,10 @@ agents:
         - MCP server in this repo: `mcp_automl_template/` (README, tool configuration, deploy)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/autogen/templates/mcp_agent
       framework: autogen
+      labels:
+        - mcp
+        - tool-calling
+      logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiM0QjhCQkUiLz4KICA8Y2lyY2xlIGN4PSIzMiIgY3k9IjMyIiByPSIxOCIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyLjUiIGZpbGw9Im5vbmUiLz4KICA8dGV4dCB4PSIzMiIgeT0iMzgiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGZvbnQtZmFtaWx5PSJBcmlhbCxIZWx2ZXRpY2Esc2Fucy1zZXJpZiIgZm9udC13ZWlnaHQ9ImJvbGQiIGZvbnQtc2l6ZT0iMTgiIGZpbGw9IndoaXRlIj5BRzwvdGV4dD4KPC9zdmc+
       env:
         - name: API_KEY
           required: true
@@ -3170,6 +3226,9 @@ agents:
           required: false
         - name: MCP_SERVER_URL
           required: false
+      templates:
+        - name: agent.yaml
+          content: '{"description":"AutoGen-based agent with MCP tools over SSE. Connects to an MCP server, loads tools dynamically, and answers user questions via an OpenAI-compatible API.","displayName":"AutoGen Agent (MCP)","env":{"optional":["PORT","CONTAINER_IMAGE","MCP_SERVER_URL"],"required":["API_KEY","BASE_URL","MODEL_ID"]},"framework":"autogen","labels":["mcp","tool-calling"],"logo":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiM0QjhCQkUiLz4KICA8Y2lyY2xlIGN4PSIzMiIgY3k9IjMyIiByPSIxOCIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyLjUiIGZpbGw9Im5vbmUiLz4KICA8dGV4dCB4PSIzMiIgeT0iMzgiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGZvbnQtZmFtaWx5PSJBcmlhbCxIZWx2ZXRpY2Esc2Fucy1zZXJpZiIgZm9udC13ZWlnaHQ9ImJvbGQiIGZvbnQtc2l6ZT0iMTgiIGZpbGw9IndoaXRlIj5BRzwvdGV4dD4KPC9zdmc+","name":"autogen-mcp-agent"}'
     - name: google-adk-agent
       displayName: Google ADK Agent
       description: General-purpose agent using Google ADK 2.0 with LiteLLM to route inference through an OGX-compatible endpoint.
@@ -3535,6 +3594,9 @@ agents:
         MIT License
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/google/templates/adk
       framework: google-adk
+      labels:
+        - tool-calling
+      logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiM0Mjg1RjQiLz4KICA8cGF0aCBkPSJNMzIgMTZjLTguOCAwLTE2IDcuMi0xNiAxNnM3LjIgMTYgMTYgMTZjNC40IDAgOC4xLTEuOCAxMC45LTQuNmwtNC40LTQuNEMzNi44IDQwLjYgMzQuNiA0MS41IDMyIDQxLjVjLTUuMiAwLTkuNS00LjMtOS41LTkuNXM0LjMtOS41IDkuNS05LjVjMi42IDAgNC45IDEgNi42IDIuN0w0Mi44IDIxQzQwLjEgMTggMzYuMyAxNiAzMiAxNnoiIGZpbGw9IndoaXRlIi8+CiAgPHJlY3QgeD0iMzEiIHk9IjI5IiB3aWR0aD0iMTciIGhlaWdodD0iNiIgcng9IjEiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPg==
       env:
         - name: API_KEY
           required: true
@@ -3546,6 +3608,9 @@ agents:
           required: false
         - name: CONTAINER_IMAGE
           required: false
+      templates:
+        - name: agent.yaml
+          content: '{"description":"General-purpose agent using Google ADK 2.0 with LiteLLM to route inference through an OGX-compatible endpoint.","displayName":"Google ADK Agent","env":{"optional":["PORT","CONTAINER_IMAGE"],"required":["API_KEY","BASE_URL","MODEL_ID"]},"framework":"google-adk","labels":["tool-calling"],"logo":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiM0Mjg1RjQiLz4KICA8cGF0aCBkPSJNMzIgMTZjLTguOCAwLTE2IDcuMi0xNiAxNnM3LjIgMTYgMTYgMTZjNC40IDAgOC4xLTEuOCAxMC45LTQuNmwtNC40LTQuNEMzNi44IDQwLjYgMzQuNiA0MS41IDMyIDQxLjVjLTUuMiAwLTkuNS00LjMtOS41LTkuNXM0LjMtOS41IDkuNS05LjVjMi42IDAgNC45IDEgNi42IDIuN0w0Mi44IDIxQzQwLjEgMTggMzYuMyAxNiAzMiAxNnoiIGZpbGw9IndoaXRlIi8+CiAgPHJlY3QgeD0iMzEiIHk9IjI5IiB3aWR0aD0iMTciIGhlaWdodD0iNiIgcng9IjEiIGZpbGw9IndoaXRlIi8+Cjwvc3ZnPg==","name":"google-adk-agent"}'
     - name: langflow-simple-tool-calling-agent
       displayName: Langflow Simple Tool Calling Agent
       description: Tool-calling agent built with Langflow's visual flow builder. Calls external APIs as tools and reasons over results.
@@ -3843,6 +3908,26 @@ agents:
         - [National Park Service API](https://developer.nps.gov) — Park search and alerts (free key required)
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/langflow/templates/simple_tool_calling_agent
       framework: langflow
+      labels:
+        - tool-calling
+        - low-code
+      logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiNGRjZCMzUiLz4KICA8cmVjdCB4PSIxMCIgeT0iMTQiIHdpZHRoPSIxNiIgaGVpZ2h0PSIxMCIgcng9IjMiIGZpbGw9IndoaXRlIi8+CiAgPHJlY3QgeD0iMzgiIHk9IjE0IiB3aWR0aD0iMTYiIGhlaWdodD0iMTAiIHJ4PSIzIiBmaWxsPSJ3aGl0ZSIvPgogIDxyZWN0IHg9IjI0IiB5PSI0MCIgd2lkdGg9IjE2IiBoZWlnaHQ9IjEwIiByeD0iMyIgZmlsbD0id2hpdGUiLz4KICA8bGluZSB4MT0iMTgiIHkxPSIyNCIgeDI9IjE4IiB5Mj0iMzQiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMi41Ii8+CiAgPGxpbmUgeDE9IjE4IiB5MT0iMzQiIHgyPSIzMiIgeTI9IjM0IiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIuNSIvPgogIDxsaW5lIHgxPSIzMiIgeTE9IjM0IiB4Mj0iMzIiIHkyPSI0MCIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyLjUiLz4KICA8bGluZSB4MT0iNDYiIHkxPSIyNCIgeDI9IjQ2IiB5Mj0iMzQiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMi41Ii8+CiAgPGxpbmUgeDE9IjQ2IiB5MT0iMzQiIHgyPSIzMiIgeTI9IjM0IiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIuNSIvPgo8L3N2Zz4=
+      env:
+        - name: POSTGRES_USER
+          required: true
+        - name: POSTGRES_PASSWORD
+          required: true
+        - name: POSTGRES_DB
+          required: true
+        - name: LANGFUSE_ADMIN_PASSWORD
+          required: false
+        - name: LANGFUSE_ENCRYPTION_KEY
+          required: false
+        - name: OLLAMA_BASE_URL
+          required: false
+      templates:
+        - name: agent.yaml
+          content: '{"deploymentModel":"flow-import","description":"Tool-calling agent built with Langflow''s visual flow builder. Calls external APIs as tools and reasons over results.","displayName":"Langflow Simple Tool Calling Agent","env":{"optional":["LANGFUSE_ADMIN_PASSWORD","LANGFUSE_ENCRYPTION_KEY","OLLAMA_BASE_URL"],"required":["POSTGRES_USER","POSTGRES_PASSWORD","POSTGRES_DB"]},"framework":"langflow","labels":["tool-calling","low-code"],"logo":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiNGRjZCMzUiLz4KICA8cmVjdCB4PSIxMCIgeT0iMTQiIHdpZHRoPSIxNiIgaGVpZ2h0PSIxMCIgcng9IjMiIGZpbGw9IndoaXRlIi8+CiAgPHJlY3QgeD0iMzgiIHk9IjE0IiB3aWR0aD0iMTYiIGhlaWdodD0iMTAiIHJ4PSIzIiBmaWxsPSJ3aGl0ZSIvPgogIDxyZWN0IHg9IjI0IiB5PSI0MCIgd2lkdGg9IjE2IiBoZWlnaHQ9IjEwIiByeD0iMyIgZmlsbD0id2hpdGUiLz4KICA8bGluZSB4MT0iMTgiIHkxPSIyNCIgeDI9IjE4IiB5Mj0iMzQiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMi41Ii8+CiAgPGxpbmUgeDE9IjE4IiB5MT0iMzQiIHgyPSIzMiIgeTI9IjM0IiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIuNSIvPgogIDxsaW5lIHgxPSIzMiIgeTE9IjM0IiB4Mj0iMzIiIHkyPSI0MCIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyLjUiLz4KICA8bGluZSB4MT0iNDYiIHkxPSIyNCIgeDI9IjQ2IiB5Mj0iMzQiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMi41Ii8+CiAgPGxpbmUgeDE9IjQ2IiB5MT0iMzQiIHgyPSIzMiIgeTI9IjM0IiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjIuNSIvPgo8L3N2Zz4=","name":"langflow-simple-tool-calling-agent"}'
       customProperties:
         deploymentModel:
             metadataType: MetadataStringValue
@@ -4268,6 +4353,34 @@ agents:
         | `Service` + `Route` ×2 | HTTPS; hosts feed Agent Card URLs |
         | In-cluster | `CREW_A2A_URL=http://a2a-crew-agent:8080` |
 
+        ## Testing
+
+        ### Unit tests
+
+        ```bash
+        make test
+        ```
+
+        ### Behavioral tests
+
+        Behavioral tests validate tool selection, response quality, latency, and reliability of the LangGraph orchestrator via its `/chat/completions` endpoint.
+
+        ```bash
+        # Set the agent URL (LangGraph server)
+        export A2A_LANGGRAPH_CREWAI_AGENT_URL="https://<langgraph-route>"
+
+        # Optional: enable MLflow trace enrichment for tool_calls extraction
+        export MLFLOW_TRACKING_URI="https://<mlflow-route>"
+        export MLFLOW_EXPERIMENT_NAME="<mlflow-experiment-name>"
+
+        # Run behavioral tests
+        pytest agents/a2a/templates/langgraph_crewai_agent/tests/behavioral/ -m a2a_langgraph_crewai -v
+        ```
+
+        **Note:** This is a multi-pod agent. Behavioral tests target the **LangGraph server** (`a2a-langgraph-agent`), which delegates to the CrewAI specialist (`a2a-crew-agent`) via the A2A protocol. Both pods must be running for tool-delegation tests to pass.
+
+        ---
+
         ## Resources
 
         - [A2A Python SDK](https://pypi.org/project/a2a-sdk/)
@@ -4276,6 +4389,10 @@ agents:
         - Related patterns: `agents/google/templates/adk/` (Helm + `make build` / `make push` / `make deploy`), `agents/llamaindex/templates/websearch_agent/`, `agents/langgraph/templates/react_agent/`
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/a2a/templates/langgraph_crewai_agent
       framework: a2a
+      labels:
+        - multi-agent
+        - a2a
+      logo: data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiMxMEI5ODEiLz4KICA8Y2lyY2xlIGN4PSIyMCIgY3k9IjMyIiByPSI3IiBmaWxsPSJ3aGl0ZSIvPgogIDxjaXJjbGUgY3g9IjQ0IiBjeT0iMzIiIHI9IjciIGZpbGw9IndoaXRlIi8+CiAgPGxpbmUgeDE9IjI3IiB5MT0iMzIiIHgyPSIzNyIgeTI9IjMyIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjMiLz4KICA8cGF0aCBkPSJNMTcgMjlsMyAzLTMgMyIgc3Ryb2tlPSIjMTBCOTgxIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPgogIDxwYXRoIGQ9Ik00NyAyOWwtMyAzIDMgMyIgc3Ryb2tlPSIjMTBCOTgxIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPgo8L3N2Zz4=
       env:
         - name: API_KEY
           required: true
@@ -4289,1271 +4406,85 @@ agents:
           required: false
         - name: CONTAINER_IMAGE_LANGGRAPH
           required: false
-    - name: claude-code
-      displayName: Claude Code on OpenShift
-      description: Deploy Claude Code on OpenShift with multiple backend options (Anthropic API, Vertex AI, vLLM, OGX).
-      readme: |
-        # Claude Code on OpenShift
-
-        A guide to deploying Claude Code as a containerized agent on Red Hat OpenShift. Supports four backend configurations: Anthropic API, Google Vertex AI, vLLM direct, and vLLM via OGX gateway.
-
-        ## Table of Contents
-
-        - [Licensing Notice](#licensing-notice)
-        - [Prerequisites](#prerequisites)
-        - [Step 1: Build the Container Image](#step-1-build-the-container-image)
-        - [Step 2: Create an OpenShift Project](#step-2-create-an-openshift-project)
-        - [Step 3: Choose Your Backend](#step-3-choose-your-backend)
-          - [Option A: Anthropic API](#option-a-anthropic-api)
-          - [Option B: Vertex AI](#option-b-vertex-ai)
-          - [Option C: vLLM Direct](#option-c-vllm-direct)
-          - [Option D: vLLM via OGX Gateway](#option-d-vllm-via-ogx-gateway)
-        - [Using Claude Code](#using-claude-code)
-        - [Configuration](#configuration)
-        - [MLflow Tracing (Optional)](#mlflow-tracing-optional)
-        - [Security Considerations](#security-considerations)
-        - [Troubleshooting](#troubleshooting)
-        - [Cleanup](#cleanup)
-        - [Known Limitations](#known-limitations)
-
-        ---
-
-        ## Licensing Notice
-
-        **Do not redistribute built container images.** The Containerfile installs Claude Code at build time via Anthropic's native installer. The resulting image contains Anthropic's proprietary binary, which is subject to their [commercial terms](https://code.claude.com/docs/en/legal-and-compliance) ("All rights reserved"). Building the image yourself for internal use is permitted, but redistributing the built image (e.g., pushing to a public registry) is not authorized.
-
-        ---
-
-        ## Prerequisites
-
-        - `podman` installed locally (on macOS, also run `podman machine init` and `podman machine start`)
-        - `oc` CLI installed and logged into your OpenShift cluster
-        - An Anthropic API key, a GCP service account key for Vertex AI, or a vLLM/OGX endpoint (no Anthropic credentials needed for self-hosted models)
-
-        All shell commands in this guide assume you are in the `deployment/` subdirectory, where the Containerfile and deployment manifests live:
-
-        ```bash
-        cd deployment/
-        ```
-
-        ---
-
-        ## Step 1: Build the Container Image
-
-        ```bash
-        podman build -t claude-code:latest -f Containerfile .
-
-        # Build with a specific version
-        podman build --build-arg CLAUDE_CODE_VERSION=2.1.123 -t claude-code:2.1.123 -f Containerfile .
-        ```
-
-        To verify the build locally, see the local test command in your chosen backend option below.
-
-        ---
-
-        ## Step 2: Create an OpenShift Project
-
-        ```bash
-        oc new-project my-claude-project
-        ```
-
-        ---
-
-        ## Step 3: Choose Your Backend
-
-        Follow **one** option below, then continue to [Using Claude Code](#using-claude-code).
-
-        | Option | Backend | Manifest | Deployment Name |
-        |--------|---------|----------|-----------------|
-        | [A](#option-a-anthropic-api) | Anthropic API | `deployment.yaml` | `claude-code` |
-        | [B](#option-b-vertex-ai) | Google Vertex AI | `deployment-vertex.yaml` | `claude-code-vertex` |
-        | [C](#option-c-vllm-direct) | vLLM Direct | `deployment-vllm.yaml` | `claude-code-vllm` |
-        | [D](#option-d-vllm-via-ogx-gateway) | vLLM via OGX | `deployment-ogx-vllm.yaml` | `claude-code-ogx-vllm` |
-
-        ---
-
-        ### Option A: Anthropic API
-
-        #### Get your API key
-
-        1. Go to [console.anthropic.com](https://console.anthropic.com/)
-        2. Sign in or create an account
-        3. Navigate to **API Keys** and click **Create Key**
-        4. Copy the key (starts with `sk-ant-api03-...`)
-
-        You need a paid account with credits.
-
-        #### Local test (optional)
-
-        ```bash
-        podman run --rm \
-          -e ANTHROPIC_API_KEY="sk-ant-api03-YOUR_KEY_HERE" \
-          claude-code:latest \
-          claude -p "What is 2+2?"
-        ```
-
-        #### Deploy
-
-        ```bash
-        # Create secret
-        oc create secret generic claude-credentials \
-          --from-literal=ANTHROPIC_API_KEY="sk-ant-api03-YOUR_KEY_HERE"
-
-        # Apply manifest and build
-        oc apply -f deployment.yaml
-        oc start-build claude-code --from-dir=. --follow
-
-        # Wait and test
-        oc rollout status deployment/claude-code
-        oc exec deployment/claude-code -- bash -c '
-          ~/.claude/claude-run -p "What is 2+2?"
-        '
-        ```
-
-        ---
-
-        ### Option B: Vertex AI
-
-        #### Get your GCP credentials
-
-        You need a GCP service account with Vertex AI access.
-
-        **Option 1: GCP Console**
-
-        1. Go to [GCP Console](https://console.cloud.google.com)
-        2. Select your project (Vertex AI API must be enabled)
-        3. Navigate to **IAM & Admin > Service Accounts**
-        4. Click **+ CREATE SERVICE ACCOUNT**
-           - Name: `claude-code-user`
-           - Grant role: **Vertex AI User** (`roles/aiplatform.user`)
-        5. Click the service account > **Keys** tab
-        6. Click **Add Key > Create new key > JSON**
-        7. Save the downloaded key file
-
-        Creating service accounts requires **IAM Admin** or **Service Account Admin** permissions.
-
-        **Option 2: gcloud CLI**
-
-        ```bash
-        gcloud iam service-accounts create claude-code-user \
-          --display-name="Claude Code User"
-
-        gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
-          --member="serviceAccount:claude-code-user@YOUR_PROJECT_ID.iam.gserviceaccount.com" \
-          --role="roles/aiplatform.user"
-
-        gcloud iam service-accounts keys create ~/claude-vertex-key.json \
-          --iam-account=claude-code-user@YOUR_PROJECT_ID.iam.gserviceaccount.com
-        ```
-
-        **Alternative: Application Default Credentials (ADC)**
-
-        If you already have credentials via `gcloud auth application-default login`, you can use your ADC file (typically at `~/.config/gcloud/application_default_credentials.json`) in place of a service account key. ADC credentials are user-scoped and typically carry broader permissions. Use ADC for local development only; for shared clusters, create a dedicated service account.
-
-        #### Local test (optional)
-
-        ```bash
-        podman run --rm \
-          -e CLAUDE_CODE_USE_VERTEX=1 \
-          -e ANTHROPIC_VERTEX_PROJECT_ID="your-gcp-project-id" \
-          -e CLOUD_ML_REGION="global" \
-          -e GOOGLE_APPLICATION_CREDENTIALS="/var/secrets/google/key.json" \
-          -v /path/to/your-service-account-key.json:/var/secrets/google/key.json:ro,z \
-          claude-code:latest \
-          claude -p "What is 2+2?"
-        ```
-
-        #### Deploy
-
-        ```bash
-        # Create secret
-        oc create secret generic claude-vertex-credentials \
-          --from-file=key.json=/path/to/your-service-account-key.json
-
-        # Apply manifest
-        oc apply -f deployment-vertex.yaml
-
-        # Patch ConfigMap with your project details
-        oc patch configmap claude-vertex-config \
-          -p '{"data":{"ANTHROPIC_VERTEX_PROJECT_ID":"your-gcp-project-id","CLOUD_ML_REGION":"global"}}'
-
-        # Build and deploy
-        oc start-build claude-code --from-dir=. --follow
-        oc rollout restart deployment/claude-code-vertex
-        oc rollout status deployment/claude-code-vertex
-
-        # Test
-        oc exec deployment/claude-code-vertex -- bash -c '
-          ~/.claude/claude-run -p "What is 2+2?"
-        '
-        ```
-
-        **Model selection:** On Vertex AI, the default `sonnet` model alias may resolve to an older model than on the direct Anthropic API. To use a specific version:
-
-        ```bash
-        oc set env deployment/claude-code-vertex CLAUDE_MODEL=claude-sonnet-4-6
-        ```
-
-        ---
-
-        ### Option C: vLLM Direct
-
-        Connects Claude Code directly to a vLLM server's `/v1/messages` endpoint.
-
-        ```text
-        Claude Code pod  ──HTTP──>  vLLM server (/v1/messages)
-        ```
-
-        #### Prerequisites
-
-        - A vLLM server with `/v1/messages` endpoint support. If you need to deploy one, see [vllm/README.md](vllm/README.md).
-        - **Context window**: minimum 32K tokens (Claude Code's system prompt is ~23K). For realistic coding work, **128K+ is strongly recommended** since CLAUDE.md, skills, file listings, and conversation easily push past 100K tokens.
-        - Network connectivity from your OpenShift cluster to the vLLM server. See [Network Connectivity](#network-connectivity-vllmogx) in Troubleshooting if the server is outside the cluster.
-
-        **Model quality note:** Claude Code is designed for Anthropic's Claude models. Open source models may produce lower quality results, particularly for complex multi-step tasks. Including language runtimes in the container (see [Extending the Container Image](#extending-the-container-image)) helps because the agent can run tests and catch its own mistakes.
-
-        #### Edit the deployment manifest
-
-        Edit `deployment-vllm.yaml`. Search for placeholder values and replace them:
-
-        - `ANTHROPIC_BASE_URL`: Your vLLM server's base URL, for example:
-          - `http://my-vllm-service.namespace.svc.cluster.local` (cluster-internal)
-          - `https://vllm.apps.cluster.example.com` (external route)
-
-        Replace model IDs in the **ConfigMap** and the **Deployment** env vars. If your vLLM server hosts only one model, use the same model ID everywhere. If it hosts multiple models, you can assign different models to each role (e.g., a small fast model for haiku, a mid-range model for sonnet, and your most capable model for opus).
-
-        | Variable | Purpose | Example (single model) |
-        |----------|---------|----------------------|
-        | ConfigMap `"model"` | Default model in `settings.json` | `gpt-oss-120b` |
-        | `CLAUDE_MODEL` | Main conversation model (overrides ConfigMap) | `gpt-oss-120b` |
-        | `ANTHROPIC_CUSTOM_MODEL_OPTION` | Adds model to the interactive mode picker menu | `gpt-oss-120b` |
-        | `ANTHROPIC_DEFAULT_HAIKU_MODEL` | What the `haiku` alias resolves to (used for background tasks like summarization) | `gpt-oss-120b` |
-        | `ANTHROPIC_DEFAULT_SONNET_MODEL` | What the `sonnet` alias resolves to (selectable via `/model sonnet`) | `gpt-oss-120b` |
-        | `ANTHROPIC_DEFAULT_OPUS_MODEL` | What the `opus` alias resolves to (selectable via `/model opus`, used for plan mode) | `gpt-oss-120b` |
-
-        The three alias overrides are required. Without them, Claude Code tries to resolve haiku, sonnet, and opus to Anthropic model names (e.g., `claude-haiku-4-5-20251001`), which don't exist on vLLM, causing 404 errors.
-
-        #### Context window configuration
-
-        Claude Code defaults to a 180K context window, which causes failures on models with smaller windows. Configure these env vars in the deployment manifest:
-
-        - `CLAUDE_CODE_AUTO_COMPACT_WINDOW`: Your model's context window in tokens (e.g., `131072`). Do not pre-subtract output tokens.
-        - `CLAUDE_CODE_MAX_OUTPUT_TOKENS`: Output budget (e.g., `28000`).
-        - `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`: Autocompaction threshold. Formula: `percentage <= (context_window - max_output_tokens) / context_window * 100`
-
-        | Model | Context | AUTO_COMPACT_WINDOW | MAX_OUTPUT_TOKENS | AUTOCOMPACT_PCT |
-        |-------|---------|--------------------|--------------------|-----------------|
-        | *(32K minimum example)* | 32K | 32768 | 4000 | 85 |
-        | RedHatAI/Qwen3.6-35B-A3B-NVFP4 | 131K | 131072 | 28000 | 75 |
-        | Qwen/Qwen3-235B-A22B | 131K | 131072 | 28000 | 75 |
-        | openai/gpt-oss-120b | 131K | 131072 | 28000 | 75 |
-        | ibm-granite/granite-4.1-8b-instruct | 524K | 524288 | 64000 | 83 |
-        | meta-llama/Llama-4-Maverick-17B-128E | 1,048K | 1048576 | 64000 | 83 |
-
-        Models with 500K+ context can use the default 83% threshold. Models with smaller context windows need a lower percentage to leave sufficient headroom for output tokens. A 32K model is the minimum supported; expect frequent autocompaction and limited conversation depth at this size.
-
-        #### Local test (optional)
-
-        ```bash
-        podman run --rm \
-          -e ANTHROPIC_BASE_URL="https://YOUR_VLLM_ENDPOINT" \
-          -e ANTHROPIC_AUTH_TOKEN="fake" \
-          claude-code:latest \
-          claude --model YOUR_MODEL_ID -p "What is 2+2?"
-        ```
-
-        #### Deploy
-
-        ```bash
-        oc apply -f deployment-vllm.yaml
-        oc start-build claude-code --from-dir=. --follow
-        oc rollout status deployment/claude-code-vllm
-
-        oc exec deployment/claude-code-vllm -- bash -c '
-          ~/.claude/claude-run -p "What is 2+2?"
-        '
-        ```
-
-        ---
-
-        ### Option D: vLLM via OGX Gateway
-
-        Uses OGX (from RHOAI) as an API gateway between Claude Code and vLLM.
-
-        ```text
-        Claude Code pod  ──HTTP──>  OGX (API Gateway)  ──HTTP──>  vLLM server
-        ```
-
-        #### Prerequisites
-
-        - OGX deployed and serving `GET /v1/health`, `GET /v1/models`, and `POST /v1/messages`. See [`ogx/README.md`](ogx/README.md) for one standalone deployment pattern, or reuse an existing OGX endpoint in your cluster.
-        - A vLLM server accessible from OGX.
-        - **Context window**: minimum 32K tokens. **128K+ strongly recommended** for realistic coding work.
-
-        **Model quality note:** Claude Code is designed for Anthropic's Claude models. Open source models may produce lower quality results, particularly for complex multi-step tasks. Including language runtimes in the container (see [Extending the Container Image](#extending-the-container-image)) helps because the agent can run tests and catch its own mistakes.
-
-        #### Edit the deployment manifest
-
-        Edit `deployment-ogx-vllm.yaml`. Search for placeholder values and replace them:
-
-        - `ANTHROPIC_BASE_URL`: Your OGX route URL (replace `YOUR_OGX_URL`)
-
-        Replace model IDs in the **ConfigMap** and the **Deployment** env vars. OGX uses the `vllm/` prefix to route requests to the vLLM backend, so all model IDs must use the exact `vllm/<model-id>` value returned by `GET /v1/models`. If OGX serves only one model, use the same value everywhere. If it serves multiple models, you can assign different models to each role.
-
-        | Variable | Purpose | Example (single model) |
-        |----------|---------|----------------------|
-        | ConfigMap `"model"` | Default model in `settings.json` | `vllm/gpt-oss-120b` |
-        | `CLAUDE_MODEL` | Main conversation model (overrides ConfigMap) | `vllm/gpt-oss-120b` |
-        | `ANTHROPIC_CUSTOM_MODEL_OPTION` | Adds model to the interactive mode picker menu | `vllm/gpt-oss-120b` |
-        | `ANTHROPIC_DEFAULT_HAIKU_MODEL` | What the `haiku` alias resolves to (used for background tasks like summarization) | `vllm/gpt-oss-120b` |
-        | `ANTHROPIC_DEFAULT_SONNET_MODEL` | What the `sonnet` alias resolves to (selectable via `/model sonnet`) | `vllm/gpt-oss-120b` |
-        | `ANTHROPIC_DEFAULT_OPUS_MODEL` | What the `opus` alias resolves to (selectable via `/model opus`, used for plan mode) | `vllm/gpt-oss-120b` |
-
-        The three alias overrides are required. Without them, Claude Code tries to resolve haiku, sonnet, and opus to Anthropic model names, causing 404 errors.
-
-        #### Deploy
-
-        ```bash
-        oc apply -f deployment-ogx-vllm.yaml
-        oc start-build claude-code --from-dir=. --follow
-        oc rollout status deployment/claude-code-ogx-vllm
-
-        oc exec deployment/claude-code-ogx-vllm -- bash -c '
-          ~/.claude/claude-run -p "What is 2+2?"
-        '
-        ```
-
-        ---
-
-        ## Using Claude Code
-
-        The examples below use `claude-code` as the deployment name. Substitute the name from the [backend table](#step-3-choose-your-backend) if you chose a different option.
-
-        ### Running Prompts
-
-        The `claude-run` wrapper includes all container-configured arguments (permission bypass, MCP config, model selection):
-
-        ```bash
-        oc exec deployment/claude-code -- bash -c '
-          ~/.claude/claude-run -p "Your prompt here"
-        '
-        ```
-
-        You can also source the environment directly:
-
-        ```bash
-        oc exec deployment/claude-code -- bash -c '
-          source ~/.claude/env.sh
-          claude $CLAUDE_EXTRA_ARGS -p "Your prompt here"
-        '
-        ```
-
-        ### Interactive Mode
-
-        For multi-turn conversations with a TTY:
-
-        ```bash
-        # OpenShift
-        oc exec -it deployment/claude-code -- bash -c '
-          ~/.claude/claude-run
-        '
-
-        # Local (example with Anthropic API; substitute env vars for your backend)
-        podman run -it --rm \
-          -e ANTHROPIC_API_KEY="sk-ant-api03-YOUR_KEY_HERE" \
-          -v $(pwd):/workspace:z \
-          claude-code:latest \
-          claude
-        ```
-
-        Interactive mode requires the `-it` flags for both `podman` and `oc exec`.
-
-        ### Debug Mode
-
-        ```bash
-        # Full debug logging
-        oc exec -it deployment/claude-code -- bash -c 'claude --debug'
-
-        # API calls only
-        oc exec -it deployment/claude-code -- bash -c 'claude --debug api'
-        ```
-
-        Debug logs are written to a file. To tail them in real time from a second terminal:
-
-        ```bash
-        oc exec deployment/claude-code -- bash -c 'tail -f /home/claude-agent/.claude/debug/*.txt'
-        ```
-
-        ### Retrieving Files from the Container
-
-        When Claude Code generates files (reports, documents, code) that you want locally without pushing to Git, use `oc cp`:
-
-        ```bash
-        # Copy a single file
-        oc cp <pod-name>:/workspace/projects/report.md ./report.md
-
-        # Copy a directory
-        oc cp <pod-name>:/workspace/projects/output/ ./output/
-
-        # Find the pod name
-        oc get pods -l app=claude-code -o name
-
-        # List files in the container
-        oc exec deployment/claude-code -- ls -la /workspace/projects/
-        ```
-
-        ### Rebuilding the Image
-
-        After modifying the Containerfile or entrypoint, rebuild and update the deployment:
-
-        ```bash
-        # Build and push the new image
-        oc start-build claude-code --from-dir=. --follow
-
-        # Update the deployment to use the new image
-        oc set image deployment/<your-deployment-name> \
-          claude-code=$(oc get istag claude-code:latest -o jsonpath='{.image.dockerImageReference}')
-        ```
-
-        `oc rollout restart` alone is not sufficient. OpenShift pins deployments to a specific image digest, so restarting just recreates the pod with the old image. You must update the image reference with `oc set image` to pick up the new build.
-
-        ---
-
-        ## Configuration
-
-        ### Session Persistence
-
-        Session history and memory persist across pod restarts via the workspace PVC. The `CLAUDE_CONFIG_DIR` environment variable points to `/workspace/.claude/`.
-
-        **Directory structure:**
-
-        ```text
-        /workspace/                      <- PVC mount (persistent)
-        |-- .claude/                     <- Global config (CLAUDE_CONFIG_DIR)
-        |   |-- settings.json            <- Copied from ConfigMap at startup
-        |   |-- skills/                  <- ConfigMap mount
-        |   |-- memory/                  <- Persisted (global memory)
-        |   +-- projects/                <- Persisted (session history)
-        +-- projects/                    <- WORKDIR (where users run Claude)
-            +-- .claude/                 <- Local auto-memory (separate from global)
-        ```
-
-        This structure separates global config (`/workspace/.claude/`) from local auto-memory (`/workspace/projects/.claude/`), mirroring the experience of running Claude Code locally.
-
-        **What persists:**
-
-        | Data | Location | Persisted? |
-        |------|----------|------------|
-        | Session history | `/workspace/.claude/projects/` | Yes |
-        | Global memory | `/workspace/.claude/memory/` | Yes |
-        | Local auto-memory | `/workspace/projects/.claude/` | Yes |
-        | Project files | `/workspace/projects/` | Yes |
-        | Skills | `/etc/claude-skills/` (symlinked to `$CLAUDE_CONFIG_DIR/skills/`) | ConfigMap (re-mounted each restart) |
-        | Settings | `${CLAUDE_CONFIG_DIR}/settings.json` | Copied from ConfigMap on first start |
-
-        The entrypoint creates a symlink `~/.claude` -> `/workspace/.claude/` so that standard `~/.claude/` paths work as expected.
-
-        **Disabling persistence:** Set `CLAUDE_CONFIG_DIR` to a non-PVC path:
-
-        ```yaml
-        env:
-          - name: CLAUDE_CONFIG_DIR
-            value: "/tmp/.claude"
-        ```
-
-        ### Injecting Skills
-
-        Skills extend Claude Code with custom instructions. They are auto-discovered from `~/.claude/skills/`. The skills ConfigMap is mounted at `/etc/claude-skills/` and the entrypoint symlinks it into `$CLAUDE_CONFIG_DIR/skills/`. Each skill must be in a subdirectory containing a `SKILL.md` file.
-
-        **Upgrading from older deployments:** If your PVC has an existing `skills/` directory from a previous deployment, the entrypoint automatically moves it to `skills.bak/` before creating the symlink.
-
-        **1. Create a SKILL.md file:**
-
-        ```markdown
-        # Code Review
-
-        When reviewing code, analyze for:
-
-        1. **Correctness** - Logic errors, edge cases, off-by-one errors
-        2. **Security** - Input validation, injection risks, hardcoded secrets
-        3. **Performance** - Unnecessary loops, N+1 queries, missing indexes
-
-        Provide feedback as:
-        - **Must Fix** - Bugs or security issues
-        - **Should Fix** - Performance or maintainability concerns
-        - **Consider** - Style suggestions or minor improvements
-        ```
-
-        **2. Create a ConfigMap from your skill files:**
-
-        ```bash
-        oc create configmap <skills-configmap-name> \
-          --from-file=code-review-skill=./skills/code-review/SKILL.md
-        ```
-
-        The ConfigMap name must match your deployment manifest (e.g., `claude-skills`, `claude-vllm-skills`).
-
-        **3. Add an `items` mapping to the skills volume in your deployment manifest:**
-
-        The `items` mapping is required so Kubernetes creates the `<skill-name>/SKILL.md` subdirectory structure that Claude Code expects. Without it, the file appears as a flat file and won't be discovered.
-
-        ```yaml
-        volumes:
-          - name: skills
-            configMap:
-              name: <skills-configmap-name>
-              optional: true
-              items:
-                - key: code-review-skill
-                  path: code-review/SKILL.md
-        ```
-
-        Each `items` entry maps a ConfigMap key to a path under the mount point. For multiple skills, add one entry per skill. For many skills, consider a PVC instead of a ConfigMap.
-
-        ### MCP Server Configuration
-
-        MCP (Model Context Protocol) servers extend Claude Code with additional tools. Configure via mounted config file or environment variable.
-
-        **Config file format:**
-
-        ```json
-        {
-          "mcpServers": {
-            "remote-api": {
-              "type": "http",
-              "url": "https://mcp.example.com/v1",
-              "headers": {
-                "Authorization": "Bearer ${API_TOKEN}"
-              }
-            },
-            "local-tool": {
-              "command": "/usr/bin/my-tool",
-              "args": ["--flag"],
-              "env": {
-                "TOOL_CONFIG": "/etc/tool.conf"
-              }
-            }
-          }
-        }
-        ```
-
-        **GitHub MCP example** (requires a [Personal Access Token](https://github.com/settings/tokens)). The `${GITHUB_PAT}` variable is expanded at runtime from the container's environment; inject it via a Kubernetes Secret (see below):
-
-        ```json
-        {
-          "mcpServers": {
-            "github": {
-              "type": "http",
-              "url": "https://api.githubcopilot.com/mcp/",
-              "headers": {
-                "Authorization": "Bearer ${GITHUB_PAT}"
-              }
-            }
-          }
-        }
-        ```
-
-        **Injecting secrets:** Environment variables like `${API_TOKEN}` can be injected via Kubernetes Secrets in the Deployment env section:
-
-        ```yaml
-        env:
-          - name: API_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: mcp-credentials
-                key: token
-        ```
-
-        Avoid hardcoding credentials in ConfigMap JSON.
-
-        **Transport types:**
-
-        | Type | Use case | Requirements |
-        |------|----------|--------------|
-        | `http` | Remote MCP servers (recommended) | Network access to endpoint |
-        | `sse` | Legacy remote servers | Network access to endpoint |
-        | `command` | Local process-based servers | Executable must exist in container |
-
-        The base image includes `git`, `curl`, `jq`, `bash`, and `python3`. Command-based MCP servers requiring `npx` or other runtimes need a custom image (see [Extending the Container Image](#extending-the-container-image)).
-
-        **Option 1: Mounted config file.** The manifests mount a ConfigMap to `/etc/mcp/config.json`. Update the ConfigMap (name varies by deployment: `claude-mcp-config`, `claude-vertex-mcp-config`, `claude-vllm-mcp-config`, or `claude-ogx-vllm-mcp-config`):
-
-        ```bash
-        oc patch configmap claude-mcp-config -p '{
-          "data": {
-            "config.json": "{\"mcpServers\":{\"my-api\":{\"type\":\"http\",\"url\":\"https://mcp.example.com/v1\"}}}"
-          }
-        }'
-        oc rollout restart deployment/claude-code
-        ```
-
-        **Option 2: Environment variable.** Set `MCP_CONFIG_JSON` with inline JSON in the Deployment spec:
-
-        ```yaml
-        - name: MCP_CONFIG_JSON
-          value: '{"mcpServers":{"my-api":{"type":"http","url":"https://mcp.example.com/v1"}}}'
-        ```
-
-        ### Workspace Instructions (CLAUDE.md)
-
-        Mount a `CLAUDE.md` file to the workspace directory to inject project-specific instructions:
-
-        ```bash
-        oc create configmap claude-workspace-instructions \
-          --from-file=CLAUDE.md=./CLAUDE.md
-        ```
-
-        Add to the deployment manifest:
-
-        ```yaml
-        # volumeMounts section:
-        - name: workspace-instructions
-          mountPath: /workspace/CLAUDE.md
-          subPath: CLAUDE.md
-          readOnly: true
-
-        # volumes section:
-        - name: workspace-instructions
-          configMap:
-            name: claude-workspace-instructions
-        ```
-
-        Claude Code automatically reads CLAUDE.md from the working directory and applies the instructions to the session.
-
-        ### Overriding settings.json
-
-        All manifests include a settings ConfigMap staged at a read-only path (`/etc/claude-config/settings.json`). On first start, the entrypoint copies it to `${CLAUDE_CONFIG_DIR}/settings.json` on the writable PVC. On subsequent restarts, the existing file is preserved so that runtime changes (e.g., hooks added by `mlflow autolog`) survive. To force a settings reset, delete the file from the PVC before restarting. The ConfigMap name varies by deployment (`claude-settings`, `claude-vertex-settings`, `claude-vllm-settings`, or `claude-ogx-vllm-settings`):
-
-        ```bash
-        oc patch configmap claude-settings -p '{
-          "data": {
-            "settings.json": "{\n  \"model\": \"your-model-id\"\n}"
-          }
-        }'
-        oc rollout restart deployment/claude-code
-        ```
-
-        Or edit the ConfigMap in the manifest YAML before applying:
-
-        ```yaml
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: claude-settings
-        data:
-          settings.json: |
-            {
-              "model": "your-model-id"
-            }
-        ```
-
-        ### Extending the Container Image
-
-        The base image includes `git`, `curl`, `jq`, `bash`, and `python3`. For real coding workflows, add language runtimes so the agent can run tests, lint, and build. Including the runtimes your project uses significantly improves agent output quality since the agent can run tests and catch its own mistakes.
-
-        The following example adds common development tools. Remove any you don't need:
-
-        ```dockerfile
-        # In the "Install System Dependencies" section of the Containerfile
-        RUN microdnf install -y --nodocs \
-                git \
-                curl \
-                jq \
-                python3.12 \
-                python3.12-pip \
-                # Build tools
-                make \
-                gcc \
-                tar \
-                unzip \
-                patch \
-                diffutils \
-                which \
-                # Node.js (includes npm)
-                nodejs \
-                # Go
-                golang \
-                # Java
-                java-21-openjdk-devel \
-                maven \
-                # Rust
-                rust \
-                cargo \
-            && microdnf clean all \
-            && rm -rf /var/cache/yum
-        ```
-
-        The GitHub CLI (`gh`) is not available in UBI repos and must be installed separately:
-
-        ```dockerfile
-        # Install GitHub CLI
-        ARG GH_VERSION=2.74.1
-        RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
-            | tar -xz -C /usr/local/bin --strip-components=2 "gh_${GH_VERSION}_linux_amd64/bin/gh"
-        ```
-
-        ---
-
-        ## MLflow Tracing (Optional)
-
-        The container image includes MLflow 3.12 with the `kubernetes-namespaced` auth plugin, and the entrypoint automatically configures tracing when `MLFLOW_TRACKING_URI` is set. No changes to the Containerfile or entrypoint are needed.
-
-        ### Prerequisites
-
-        - An MLflow instance running on your RHOAI cluster with a workspace matching your namespace.
-
-        ### 1. Grant RBAC
-
-        ```bash
-        oc adm policy add-role-to-user edit -z default -n <your-namespace>
-        ```
-
-        For production, use a dedicated service account with least-privilege RBAC scoped to the permissions MLflow's `kubernetes-namespaced` auth plugin requires.
-
-        ### 2. Add MLflow env vars to your deployment manifest
-
-        Uncomment the MLflow env vars in your deployment manifest (all four manifests include commented-out placeholders), or add these to the `env` section:
-
-        ```yaml
-        - name: MLFLOW_TRACKING_URI
-          value: "https://mlflow.<rhoai-namespace>.svc:8443/mlflow"
-        - name: MLFLOW_TRACKING_AUTH
-          value: "kubernetes-namespaced"
-        - name: MLFLOW_WORKSPACE
-          value: "<your-namespace>"
-        - name: MLFLOW_EXPERIMENT_NAME
-          value: "claude-code-traces"
-        - name: MLFLOW_TRACKING_INSECURE_TLS
-          value: "true"  # dev/test only; production should use proper TLS certificates
-        ```
-
-        The `<rhoai-namespace>` is commonly `redhat-ods-applications`. The `/mlflow` path suffix is required for MLflow 3.12+.
-
-        If your deployment is already running, re-apply the manifest and restart the pod to pick up the new env vars:
-
-        ```bash
-        oc apply -f <your-deployment-manifest>.yaml
-        oc rollout restart deployment/<deployment-name>
-        ```
-
-        ### 3. Verify
-
-        ```bash
-        # Check startup logs for MLflow initialization
-        oc logs deployment/<deployment-name> | grep -i mlflow
-
-        # Run a test prompt
-        oc exec deployment/<deployment-name> -- bash -c '
-          ~/.claude/claude-run -p "What is 2+2?"
-        '
-
-        # Check your MLflow UI for a new trace under the experiment name
-        ```
-
-        ### 4. View traces in the MLflow UI
-
-        Find the MLflow UI URL from the ConsoleLink:
-
-        ```bash
-        oc get consolelink mlflow -o jsonpath='{.spec.href}'
-        ```
-
-        This typically returns a URL through the RHOAI data science gateway (e.g., `https://rh-ai.<cluster-domain>/mlflow`). Open that URL in your browser and log in with the same OpenShift identity that deployed the agent. The MLflow workspace maps to the Kubernetes namespace, so you must have RBAC access to the agent's namespace to see its experiments and traces.
-
-        After login, select your workspace (the namespace name, e.g., `my-claude-code`) and navigate to the experiment you configured in `MLFLOW_EXPERIMENT_NAME`.
-
-        > **Note:** The direct MLflow route (`mlflow-<rhoai-namespace>.<cluster-domain>`) does not handle browser authentication. Always use the gateway URL from the ConsoleLink, which routes through OAuth.
-
-        ### What gets traced
-
-        Each session captures tool call sequences, token counts (input/output/total), session duration, model name, and status as OTel spans. The stop-hook fires after the session ends, so there is zero impact on agent response times. The trace schema works identically across all four backends.
-
-        ### MLflow version options
-
-        The default Containerfile uses MLflow 3.12 with a Python hook. MLflow 3.14+ also supports an npm plugin approach — uncomment the npm plugin env var in your deployment manifest to enable it. The plugin must be built from [upstream master](https://github.com/mlflow/mlflow/tree/master/libs/typescript) until the next plugin release syncs the fix. See [mlflow-tracing.md](mlflow-tracing.md) for a comparison of both approaches.
-
-        > **TLS note:** The npm plugin currently requires `NODE_TLS_REJECT_UNAUTHORIZED=0` or `NODE_EXTRA_CA_CERTS` for clusters with non-public TLS certificates. Both are process-wide Node.js settings. Upstream work is in progress to support `MLFLOW_TRACKING_INSECURE_TLS` and `MLFLOW_TRACKING_SERVER_CERT_PATH` scoped to MLflow connections only ([mlflow#24140](https://github.com/mlflow/mlflow/issues/24140)). Kubernetes-native auth (`MLFLOW_TRACKING_AUTH`) is also being added to the TypeScript SDK ([mlflow#24141](https://github.com/mlflow/mlflow/issues/24141)).
-
-        For detailed tracing investigation results and benchmark data, see [mlflow-tracing.md](mlflow-tracing.md).
-
-        ---
-
-        ## Security Considerations
-
-        ### SKIP_PERMISSIONS
-
-        The deployment manifests set `SKIP_PERMISSIONS=true` by default, passing `--dangerously-skip-permissions` to Claude Code. This disables all permission prompts, including file-system write confirmations and confirmation of destructive operations (e.g., `git push --force`).
-
-        **Why it's enabled by default:**
-
-        - The container runs as non-root with dropped capabilities and seccomp profiles
-        - Claude only has access to the isolated `/workspace` PVC, not host filesystems
-        - Permission prompts don't work well in non-interactive `oc exec` scenarios
-        - One of the main advantages of running Claude Code in an isolated container is enabling less-interrupted workflows
-
-        **Tradeoffs:** Running in an isolated container removes much of the reason you would normally keep permission checks in place: the container cannot access data that is not explicitly mounted into it. However, skipping permissions also disables guardrails against destructive operations on external services the agent can reach, such as force-pushing to a Git remote or making unintended API calls via MCP servers. If you are running interactively and want an extra layer of confirmation, you can disable `SKIP_PERMISSIONS`. But for headless or automated usage, permission prompts are not practical, and you should rely on the repository safeguards described below instead.
-
-        To disable, set `SKIP_PERMISSIONS=false` in the deployment manifest or remove the variable.
-
-        ### Repository Safeguards
-
-        When an AI agent has push access to a Git repository, ensure the repository has protections against mistakes. This is especially important with `SKIP_PERMISSIONS=true` and when using less capable models that are more likely to make errors such as committing directly to main, force-pushing, or merging their own PRs.
-
-        **Recommended protections:**
-
-        - **Branch protection rules**: Protect your main/default branch so direct pushes are blocked, forcing all changes through pull requests. On GitHub: Settings > Branches > Branch protection rules.
-        - **Required pull request reviews**: Require at least one approval from someone other than the PR author before merging. This prevents the agent from opening and immediately merging a PR without human review.
-        - **Limit PAT scope**: When creating the GitHub Personal Access Token used by the agent, grant only the minimum permissions needed. See [GitHub's documentation on token scopes](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) for fine-grained token options.
-        - **Status checks**: Require CI checks (tests, linting) to pass before a PR can be merged, so broken code cannot be merged even if a review is approved.
-
-        These protections apply regardless of whether you are using Claude Code or any other AI coding tool. They are standard best practices for collaborative development, but become critical when an automated agent has commit and push access.
-
-        ### Credential Isolation
-
-        When credentials such as GitHub PATs or API tokens are passed as environment variables or written to files inside the container, the agent can read them directly. This means the agent could inadvertently expose credentials in conversation output, commit messages, or through MCP server calls. This is a known limitation of the approach described in this guide.
-
-        For many use cases, this risk is acceptable when combined with the safeguards above: limiting PAT scope to the minimum required permissions, protecting branches, and requiring PR reviews. However, for environments with strict security requirements, the ideal approach is to isolate the agent from the credentials it depends on, so that it can use tools (like git push or GitHub APIs) without being able to see or exfiltrate the underlying secrets.
-
-        Container isolation solutions are actively exploring ways to provide this kind of separation. If credential isolation is a requirement for your deployment, consider evaluating such solutions as they mature.
-
-        ---
-
-        ## Troubleshooting
-
-        ### Network Connectivity (vLLM/OGX)
-
-        If the vLLM or OGX server is outside the cluster (e.g., on EC2 or another cloud), verify the pod can reach it:
-
-        ```bash
-        # Find the cluster's egress IP
-        oc exec deployment/claude-code-vllm -- curl -s ifconfig.me
-
-        # Test connectivity to the server
-        oc exec deployment/claude-code-vllm -- curl -s -o /dev/null -w "%{http_code}" http://YOUR_HOST:8000/v1/models
-        ```
-
-        Common causes of connection failure include security group rules, network policies, and firewalls. If the server uses IP-based access rules, add the cluster egress IP to the allow list (e.g., AWS security group inbound rule on TCP port 8000).
-
-        ### Context Window Errors
-
-        Models with insufficient context will fail with errors like:
-
-        ```text
-        API Error: 400 {"type":"error","error":{"type":"BadRequestError",
-        "message":"max_tokens must be at least 1, got -7214."}}
-        ```
-
-        This means the model's context window is too small to fit Claude Code's system prompt plus the requested output tokens. See [Context window configuration](#context-window-configuration) in Option C for how to configure the context window, autocompaction, and output budget.
-
-        ### OGX 404 Logs
-
-        When monitoring OGX logs, some 404 responses are normal:
-
-        ```bash
-        oc logs deployment/ogx --tail=50
-        ```
-
-        ```text
-        HEAD / 404        # Claude Code HTTP client probing
-        POST /v1/messages 404  # Initial probes (2x)
-        POST /v1/messages 200  # Successful request with "Using native /v1/messages passthrough"
-        ```
-
-        The 404s are caused by Claude Code's HTTP client probing behavior and do not indicate errors. The key indicator of success is seeing `Using native /v1/messages passthrough` followed by a 200 response.
-
-        ### Testing Endpoints Directly
-
-        To verify the vLLM or OGX server supports the Anthropic Messages API:
-
-        **vLLM:**
-
-        ```bash
-        # Health and model listing
-        curl -s "https://YOUR_VLLM_ENDPOINT/health"
-        curl -s "https://YOUR_VLLM_ENDPOINT/v1/models"
-
-        # Non-streaming request
-        curl -s -X POST "https://YOUR_VLLM_ENDPOINT/v1/messages" \
-          -H "Content-Type: application/json" \
-          -H "anthropic-version: 2023-06-01" \
-          -d '{
-            "model": "YOUR_MODEL_ID",
-            "max_tokens": 100,
-            "messages": [{"role": "user", "content": "What is 2+2? Reply with just the number."}]
-          }'
-
-        # Streaming request
-        curl -s -X POST "https://YOUR_VLLM_ENDPOINT/v1/messages" \
-          -H "Content-Type: application/json" \
-          -H "anthropic-version: 2023-06-01" \
-          -d '{
-            "model": "YOUR_MODEL_ID",
-            "max_tokens": 100,
-            "stream": true,
-            "messages": [{"role": "user", "content": "Say hello"}]
-          }'
-
-        # Tool calling (Claude Code uses tools extensively)
-        curl -s -X POST "https://YOUR_VLLM_ENDPOINT/v1/messages" \
-          -H "Content-Type: application/json" \
-          -H "anthropic-version: 2023-06-01" \
-          -d '{
-            "model": "YOUR_MODEL_ID",
-            "max_tokens": 1024,
-            "messages": [{"role": "user", "content": "List files in the current directory"}],
-            "tools": [{"name": "bash", "description": "Run a bash command", "input_schema": {"type": "object", "properties": {"command": {"type": "string"}}, "required": ["command"]}}]
-          }'
-        ```
-
-        **OGX:** Use the same commands with your OGX route URL and the `vllm/` model prefix reported by `GET /v1/models`:
-
-        ```bash
-        OGX_URL=<your-ogx-route-host>
-        curl -s "https://$OGX_URL/v1/health"
-        curl -s "https://$OGX_URL/v1/models"
-
-        curl -s -X POST "https://$OGX_URL/v1/messages" \
-          -H "Content-Type: application/json" \
-          -H "anthropic-version: 2023-06-01" \
-          -d '{
-            "model": "vllm/YOUR_MODEL_ID",
-            "max_tokens": 100,
-            "messages": [{"role": "user", "content": "What is 2+2? Reply with just the number."}]
-          }'
-        ```
-
-        ### Model Aliasing
-
-        vLLM supports model aliasing via `--served-model-name`, letting you serve a model under a custom name without OGX:
-
-        ```yaml
-        command:
-          - python3
-          - -m
-          - vllm.entrypoints.openai.api_server
-          - --model
-          - openai/gpt-oss-120b
-          - --served-model-name
-          - my-custom-model-name
-        ```
-
-        Then set `CLAUDE_MODEL` on the Claude Code deployment to match:
-
-        ```bash
-        oc set env deployment/claude-code CLAUDE_MODEL=my-custom-model-name
-        ```
-
-        `--served-model-name` is a **replacement**, not an addition. The original HuggingFace model ID is no longer recognized after setting an alias. To keep both the original name and an alias, pass the flag twice: `--served-model-name openai/gpt-oss-120b --served-model-name my-alias`.
-
-        ### Interactive Wizard API Key Confirmation
-
-        When launching interactive mode, Claude Code's setup wizard includes an API key confirmation page. The behavior depends on which authentication env var you use:
-
-        - **`ANTHROPIC_AUTH_TOKEN`**: The key confirmation page is skipped entirely. This is what the vLLM and OGX manifests use. Set it to `"fake"` if your backend requires no authentication, or to a real token if it does.
-        - **`ANTHROPIC_API_KEY`**: The wizard prompts you to accept or reject the key. Use this for the Anthropic API (Option A) or any backend that requires an Anthropic-style API key. You must accept the key when prompted; see below for what happens if you reject it.
-
-        **If you reject an API key**, Claude Code stores the rejection in `/workspace/.claude/.claude.json` on the PVC and redirects you to browser-based authentication. Restarting the pod does not help because the rejection is persisted on the PVC. To recover, either fix the config file or delete the PVC and redeploy:
-
-        ```bash
-        # Option 1: Fix the config file
-        oc exec deployment/<your-deployment-name> -- python3 -c '
-        import json
-        f = "/workspace/.claude/.claude.json"
-        with open(f) as fh:
-            d = json.load(fh)
-        d["customApiKeyResponses"] = {"approved": [], "rejected": []}
-        with open(f, "w") as fh:
-            json.dump(d, fh, indent=2)
-        print("Fixed: cleared key rejections")
-        '
-
-        # Option 2: Delete PVC and redeploy (full fresh start)
-        oc delete pvc <your-workspace-pvc>
-        oc rollout restart deployment/<your-deployment-name>
-        ```
-
-        ### Test Scripts
-
-        For automated validation of vLLM endpoints and Claude Code functionality, see the test scripts in [vllm/tests/](vllm/tests/). Full documentation is in [vllm/README.md](vllm/README.md).
-
-        ---
-
-        ## Cleanup
-
-        Resources to delete, by deployment option:
-
-        **Option A (Anthropic API):**
-
-        ```bash
-        oc delete deployment claude-code
-        oc delete buildconfig claude-code
-        oc delete imagestream claude-code
-        oc delete secret claude-credentials
-        oc delete configmap claude-mcp-config claude-skills claude-settings
-        oc delete pvc claude-workspace
-        oc delete project my-claude-project
-        ```
-
-        **Option B (Vertex AI):**
-
-        ```bash
-        oc delete deployment claude-code-vertex
-        oc delete buildconfig claude-code
-        oc delete imagestream claude-code
-        oc delete secret claude-vertex-credentials
-        oc delete configmap claude-vertex-config claude-vertex-mcp-config claude-vertex-skills claude-vertex-settings
-        oc delete pvc claude-vertex-workspace
-        oc delete project my-claude-project
-        ```
-
-        **Option C (vLLM direct):**
-
-        ```bash
-        oc delete deployment claude-code-vllm
-        oc delete buildconfig claude-code
-        oc delete imagestream claude-code
-        oc delete configmap claude-vllm-settings claude-vllm-mcp-config claude-vllm-skills
-        oc delete pvc claude-vllm-workspace
-        oc delete project my-claude-project
-        ```
-
-        **Option D (OGX + vLLM):**
-
-        ```bash
-        oc delete deployment claude-code-ogx-vllm
-        oc delete buildconfig claude-code
-        oc delete imagestream claude-code
-        oc delete configmap claude-ogx-vllm-settings claude-ogx-vllm-mcp-config claude-ogx-vllm-skills
-        oc delete pvc claude-ogx-vllm-workspace
-        oc delete project my-claude-project
-        ```
-
-        ---
-
-        ## Known Limitations
-
-        ### Context Window Requirement
-
-        Claude Code sends a large internal system prompt (~23K tokens) with every request. Models with insufficient context will fail. Minimum: 32K tokens. Recommended: 128K+ for multi-turn conversations with tool use.
-
-        ### Open Source Model Quality
-
-        Claude Code is designed and optimized for Anthropic's Claude models. Open source models may produce lower quality results, particularly for complex multi-step tasks, tool use chains, and code generation. Including language runtimes in the container helps because the agent can run tests and iterate on its own output.
-
-        ### LLMInferenceService vs Standalone Deployment
-
-        The KServe `LLMInferenceService` CRD adds a `storage-initializer` init container that uses HF Xet for model downloads. This can stall on large models (60GB+) due to CDN timeouts, and the CRD does not expose init container env overrides. The standalone Deployment approach (used in [vllm/README.md](vllm/README.md)) lets vLLM download the model directly with standard HTTP, which is more reliable.
-
-        Use `LLMInferenceService` when you need the llm-d router/scheduler for multi-replica intelligent routing. Use standalone Deployment for single-replica setups or when the init container stalls.
-      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/claude-code
+      templates:
+        - name: agent.yaml
+          content: '{"description":"A2A demo — CrewAI specialist and LangGraph orchestrator (one Dockerfile; two tags / image refs for deploy).","displayName":"A2A LangGraph ↔ CrewAI","env":{"optional":["CONTAINER_IMAGE","CONTAINER_IMAGE_CREW","CONTAINER_IMAGE_LANGGRAPH"],"required":["API_KEY","BASE_URL","MODEL_ID"]},"framework":"a2a","labels":["multi-agent","a2a"],"logo":"data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2NCA2NCIgZmlsbD0ibm9uZSI+CiAgPHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjY0IiByeD0iMTQiIGZpbGw9IiMxMEI5ODEiLz4KICA8Y2lyY2xlIGN4PSIyMCIgY3k9IjMyIiByPSI3IiBmaWxsPSJ3aGl0ZSIvPgogIDxjaXJjbGUgY3g9IjQ0IiBjeT0iMzIiIHI9IjciIGZpbGw9IndoaXRlIi8+CiAgPGxpbmUgeDE9IjI3IiB5MT0iMzIiIHgyPSIzNyIgeTI9IjMyIiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjMiLz4KICA8cGF0aCBkPSJNMTcgMjlsMyAzLTMgMyIgc3Ryb2tlPSIjMTBCOTgxIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPgogIDxwYXRoIGQ9Ik00NyAyOWwtMyAzIDMgMyIgc3Ryb2tlPSIjMTBCOTgxIiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCIvPgo8L3N2Zz4=","name":"a2a-langgraph-crewai"}'
+    - name: claude-code-agent
+      displayName: Claude Code
+      description: Anthropic's Claude Code CLI for AI-powered code generation, editing, and debugging tasks.
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/claude-code/templates/claude_code_agent
       framework: claude-code
-    - name: openclaw
-      displayName: OpenClaw on OpenShift
-      description: Deploy OpenClaw on OpenShift with vLLM model serving, OAuth SSO, and production-grade security.
-      readme: |
-        # OpenClaw on OpenShift
-
-        > Tested: 2026-04-13 on OpenShift 4.19 (ROSA) with vLLM model serving
-
-        Deploy [OpenClaw](https://github.com/openclaw/openclaw) on Red Hat OpenShift with vLLM model serving — no cluster-admin required.
-
-        For the full deployment guide, see [docs/raw-deployment.md](docs/raw-deployment.md).
-
-        ## Prerequisites
-
-        - OpenShift 4.17+ with namespace-scoped access (`oc login`)
-        - A model serving endpoint (vLLM, KServe, or external API)
-        - Block storage class (gp3-csi, managed-csi, thin-csi) — not NFS
-
-        ## Quick Start
-
-        ```bash
-        oc new-project my-openclaw
-
-        # Edit manifests/02-configmap.yaml with your model endpoint
-        # Edit manifests/01-secret.yaml with your gateway token
-
-        oc apply -k manifests/
-        ```
-
-        ## Architecture
-
-        ```text
-                             +-----------------------+
-                             |   OpenShift Route     |
-                             |   (TLS edge)          |
-                             +-----------+-----------+
-                                         |
-                                         v
-                      +------------------+------------------+
-                      |            Service                   |
-                      |        (ClusterIP :18789)            |
-                      +------------------+------------------+
-                                         |
-                                         v
-                      +------------------+------------------+
-                      |              Pod                     |
-                      |  +--------------------------------+  |
-                      |  | gateway                        |  |
-                      |  | port 18789                     |  |
-                      |  +---------------+----------------+  |
-                      |                  |                   |
-                      |           +------+------+            |
-                      |           | PVC (5Gi)   |            |
-                      |           +-------------+            |
-                      +--------------------------------------+
-                                 |
-                                 | OpenAI-compatible API
-                                 v
-                      +---------------------------+
-                      |  vLLM / KServe / API      |
-                      +---------------------------+
-        ```
-
-        ## Files
-
-        | File | Description |
-        |------|-------------|
-        | `manifests/01-secret.yaml` | Gateway authentication token |
-        | `manifests/02-configmap.yaml` | Model endpoint and gateway configuration |
-        | `manifests/03-pvc.yaml` | Persistent storage for gateway state |
-        | `manifests/04-deployment.yaml` | OpenClaw gateway deployment |
-        | `manifests/05-service.yaml` | ClusterIP service |
-        | `manifests/06-route.yaml` | TLS edge route |
-        | `manifests/kustomization.yaml` | Kustomize entrypoint |
-        | `overlays/example/` | Example overlay for environment-specific config |
-        | `overlays/mlflow-tracing/` | MLflow tracing via OTel collector sidecar |
-        | `Containerfile.openshell` | OpenShell sandbox image build |
-
-        ## Customization
-
-        | What | Where |
-        |------|-------|
-        | Model endpoint URL | `overlays/<env>/configmap-patch.yaml` |
-        | Storage class | `overlays/<env>/kustomization.yaml` (patch) |
-        | Namespace | `overlays/<env>/kustomization.yaml` (`namespace:` field) |
-        | Gateway token | `manifests/01-secret.yaml` |
-        | Resource limits | Patch `manifests/04-deployment.yaml` |
-
-        ## Docs
-
-        | Document | Description |
-        |----------|-------------|
-        | [docs/raw-deployment.md](docs/raw-deployment.md) | Full deployment guide: configuration, validation, troubleshooting |
-        | [docs/mlflow-tracing.md](docs/mlflow-tracing.md) | MLflow tracing with OTel collector sidecar |
-        | [docs/model-compatibility.md](docs/model-compatibility.md) | Model testing results for agentic tool-calling |
-        | [docs/troubleshooting.md](docs/troubleshooting.md) | Common issues and fixes |
-        | [docs/installer-deployment.md](docs/installer-deployment.md) | Alternative deployment via [claw-installer](https://github.com/sallyom/claw-installer) |
-
-        ## Related Projects
-
-        - [OpenClaw](https://github.com/openclaw/openclaw) — Upstream project
-        - [claw-installer](https://github.com/sallyom/claw-installer) — Web-based deployment tool with OpenShift plugin
-        - [openclaw-on-openshift](https://github.com/aakankshaduggal/openclaw-on-openshift) — Source repo with full docs
-
-        ---
-
-        ## Running in an OpenShell Sandbox
-
-        To run OpenClaw inside an [OpenShell](https://github.com/NVIDIA/OpenShell-Community) sandbox, use the `Containerfile.openshell`. This builds on the shared base image (`sandboxes/base/`) and adds Node.js and the OpenClaw CLI on top.
-
-        ### Build the OpenShell-compatible image
-
-        ```bash
-        podman build --platform linux/amd64 -t openclaw-sandbox:latest -f Containerfile.openshell .
-        ```
-
-        ### Create a sandbox
-
-        ```bash
-        openshell sandbox create --from openclaw-sandbox:latest
-        ```
-
-        ### What `Containerfile.openshell` does
-
-        Builds on the shared base image (`quay.io/hmoghani/openshell-base`) which provides the `sandbox` user, system packages, and OpenShell entrypoint. This flavor adds:
-
-        - Node.js and npm (from UBI repos)
-        - OpenClaw via npm (version pinned, MIT)
-
-        ### Notes
-
-        - OpenShell's supervisor takes over as PID 1 and does not automatically start the OpenClaw gateway. Start it manually inside the sandbox: `openclaw gateway --bind loopback --auth none --port 18789 --allow-unconfigured`
-        - Build with `--platform linux/amd64` when targeting x86_64 clusters from Apple Silicon machines.
-        - Tested on OpenShell v0.0.58, OpenShift 4.21 (June 2026).
-      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/openclaw/deployment
+      labels:
+        - coding-agent
+        - cli
+      logo: data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjFlbSIgc3R5bGU9ImZsZXg6bm9uZTtsaW5lLWhlaWdodDoxIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxZW0iIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHRpdGxlPkNsYXVkZSBDb2RlPC90aXRsZT48cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC45OTggMTAuOTQ5SDI0djMuMTAyaC0zdjMuMDI4aC0xLjQ4N1YyMEgxOHYtMi45MjFoLTEuNDg3VjIwSDE1di0yLjkyMUg5VjIwSDcuNDg4di0yLjkyMUg2VjIwSDQuNDg3di0yLjkyMUgzVjE0LjA1SDBWMTAuOTVoM1Y1aDE3Ljk5OHY1Ljk0OXpNNiAxMC45NDloMS40ODhWOC4xMDJINnYyLjg0N3ptMTAuNTEgMEgxOFY4LjEwMmgtMS40OXYyLjg0N3oiIGZpbGw9IiNEOTc3NTciIGZpbGwtcnVsZT0iZXZlbm9kZCI+PC9wYXRoPjwvc3ZnPg==
+      env:
+        - name: ANTHROPIC_API_KEY
+          required: false
+        - name: ANTHROPIC_AUTH_TOKEN
+          required: false
+        - name: ANTHROPIC_BASE_URL
+          required: false
+        - name: CLAUDE_MODEL
+          required: false
+        - name: CLAUDE_CODE_USE_VERTEX
+          required: false
+        - name: ANTHROPIC_VERTEX_PROJECT_ID
+          required: false
+        - name: CLOUD_ML_REGION
+          required: false
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          required: false
+        - name: MCP_CONFIG_JSON
+          required: false
+        - name: MCP_CONFIG_FILE
+          required: false
+        - name: GITHUB_PAT
+          required: false
+        - name: SKIP_PERMISSIONS
+          required: false
+        - name: MLFLOW_TRACKING_URI
+          required: false
+      templates:
+        - name: agent.yaml
+          content: '{"description":"Anthropic''s Claude Code CLI for AI-powered code generation, editing, and debugging tasks.","displayName":"Claude Code","env":{"optional":["ANTHROPIC_API_KEY","ANTHROPIC_AUTH_TOKEN","ANTHROPIC_BASE_URL","CLAUDE_MODEL","CLAUDE_CODE_USE_VERTEX","ANTHROPIC_VERTEX_PROJECT_ID","CLOUD_ML_REGION","GOOGLE_APPLICATION_CREDENTIALS","MCP_CONFIG_JSON","MCP_CONFIG_FILE","GITHUB_PAT","SKIP_PERMISSIONS","MLFLOW_TRACKING_URI"],"required":[]},"framework":"claude-code","labels":["coding-agent","cli"],"logo":"data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9IjFlbSIgc3R5bGU9ImZsZXg6bm9uZTtsaW5lLWhlaWdodDoxIiB2aWV3Qm94PSIwIDAgMjQgMjQiIHdpZHRoPSIxZW0iIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHRpdGxlPkNsYXVkZSBDb2RlPC90aXRsZT48cGF0aCBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0yMC45OTggMTAuOTQ5SDI0djMuMTAyaC0zdjMuMDI4aC0xLjQ4N1YyMEgxOHYtMi45MjFoLTEuNDg3VjIwSDE1di0yLjkyMUg5VjIwSDcuNDg4di0yLjkyMUg2VjIwSDQuNDg3di0yLjkyMUgzVjE0LjA1SDBWMTAuOTVoM1Y1aDE3Ljk5OHY1Ljk0OXpNNiAxMC45NDloMS40ODhWOC4xMDJINnYyLjg0N3ptMTAuNTEgMEgxOFY4LjEwMmgtMS40OXYyLjg0N3oiIGZpbGw9IiNEOTc3NTciIGZpbGwtcnVsZT0iZXZlbm9kZCI+PC9wYXRoPjwvc3ZnPg==","name":"claude-code-agent"}'
+    - name: openclaw-agent
+      displayName: OpenClaw
+      description: Open-source AI coding assistant based on OpenClaw with gateway-based model routing and multi-channel support.
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/openclaw/templates/openclaw_agent
       framework: openclaw
-    - name: codex
-      displayName: Codex on OpenShift
-      description: Run OpenAI Codex CLI inside an OpenShell sandbox on OpenShift.
-      readme: |
-        # Codex — OpenShell Sandbox Deployment
-
-        This directory contains an OpenShell-compatible Containerfile for running [OpenAI Codex CLI](https://github.com/openai/codex) inside an OpenShell sandbox.
-
-        ## Prerequisites
-
-        - [Podman](https://podman.io/) or Docker installed
-        - [OpenShell CLI](https://github.com/NVIDIA/OpenShell-Community) installed
-        - An OpenShell gateway running
-
-        ## Build and Run
-
-        ```bash
-        podman build --platform linux/amd64 -t codex-sandbox:latest -f Containerfile.openshell .
-        openshell sandbox create --from codex-sandbox:latest -e OPENAI_API_KEY=sk-...
-        ```
-
-        ## What `Containerfile.openshell` does
-
-        Builds on the shared base image (`quay.io/hmoghani/openshell-base`) which provides the `sandbox` user, system packages, and OpenShell entrypoint. This flavor adds:
-
-        - Node.js and npm (from UBI repos)
-        - Codex CLI via npm (version pinned, Apache 2.0)
-
-        ## Notes
-
-        - OpenShell's supervisor takes over as PID 1 and does not automatically run the Codex CLI. Start it manually inside the sandbox.
-        - Build with `--platform linux/amd64` when targeting x86_64 clusters from Apple Silicon machines.
-        - Tested on OpenShell v0.0.58, OpenShift 4.21 (June 2026). Codex CLI version 0.139.0.
-      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/codex/deployment
-      framework: codex
-    - name: opencode
-      displayName: OpenCode on OpenShift
-      description: Run OpenCode inside an OpenShell sandbox on OpenShift.
-      readme: |
-        # OpenCode — OpenShell Sandbox Deployment
-
-        This directory contains an OpenShell-compatible Containerfile for running [OpenCode](https://github.com/sst/opencode) inside an OpenShell sandbox.
-
-        ## Prerequisites
-
-        - [Podman](https://podman.io/) or Docker installed
-        - [OpenShell CLI](https://github.com/NVIDIA/OpenShell-Community) installed
-        - An OpenShell gateway running
-
-        ## Build and Run
-
-        ```bash
-        podman build --platform linux/amd64 -t opencode-sandbox:latest -f Containerfile.openshell .
-        openshell sandbox create --from opencode-sandbox:latest
-        ```
-
-        ## What `Containerfile.openshell` does
-
-        Builds on the shared base image (`quay.io/hmoghani/openshell-base`) which provides the `sandbox` user, system packages, and OpenShell entrypoint. This flavor adds:
-
-        - Node.js and npm (from UBI repos)
-        - OpenCode via npm (version pinned, MIT)
-
-        ## RHOAI Deployment
-
-        For deploying OpenCode on Red Hat OpenShift AI with OAuth, kustomize manifests, and production configuration, see [DEPLOYMENT.md](DEPLOYMENT.md).
-
-        ## Notes
-
-        - OpenShell's supervisor takes over as PID 1 and does not automatically run OpenCode. Start it manually inside the sandbox.
-        - Build with `--platform linux/amd64` when targeting x86_64 clusters from Apple Silicon machines.
-        - Tested on OpenShell v0.0.58, OpenShift 4.21 (June 2026). OpenCode version 1.17.1.
-      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/opencode/deployment
+      labels:
+        - coding-agent
+        - gateway
+      logo: data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTIwIDEyMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9ImxvYnN0ZXItZ3JhZGllbnQiIHgxPSIwJSIgeTE9IjAlIiB4Mj0iMTAwJSIgeTI9IjEwMCUiPjxzdG9wIG9mZnNldD0iMCUiIHN0b3AtY29sb3I9IiNmZjRkNGQiLz48c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiM5OTFiMWIiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48cGF0aCBkPSJNNjAgMTAgQzMwIDEwIDE1IDM1IDE1IDU1IEMxNSA3NSAzMCA5NSA0NSAxMDAgTDQ1IDExMCBMNTUgMTEwIEw1NSAxMDAgQzU1IDEwMCA2MCAxMDIgNjUgMTAwIEw2NSAxMTAgTDc1IDExMCBMNzUgMTAwIEM5MCA5NSAxMDUgNzUgMTA1IDU1IEMxMDUgMzUgOTAgMTAgNjAgMTBaIiBmaWxsPSJ1cmwoI2xvYnN0ZXItZ3JhZGllbnQpIi8+PHBhdGggZD0iTTIwIDQ1IEM1IDQwIDAgNTAgNSA2MCBDMTAgNzAgMjAgNjUgMjUgNTUgQzI4IDQ4IDI1IDQ1IDIwIDQ1WiIgZmlsbD0idXJsKCNsb2JzdGVyLWdyYWRpZW50KSIvPjxwYXRoIGQ9Ik0xMDAgNDUgQzExNSA0MCAxMjAgNTAgMTE1IDYwIEMxMTAgNzAgMTAwIDY1IDk1IDU1IEM5MiA0OCA5NSA0NSAxMDAgNDVaIiBmaWxsPSJ1cmwoI2xvYnN0ZXItZ3JhZGllbnQpIi8+PHBhdGggZD0iTTQ1IDE1IFEzNSA1IDMwIDgiIHN0cm9rZT0iI2ZmNGQ0ZCIgc3Ryb2tlLXdpZHRoPSIzIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz48cGF0aCBkPSJNNzUgMTUgUTg1IDUgOTAgOCIgc3Ryb2tlPSIjZmY0ZDRkIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPjxjaXJjbGUgY3g9IjQ1IiBjeT0iMzUiIHI9IjYiIGZpbGw9IiMwNTA4MTAiLz48Y2lyY2xlIGN4PSI3NSIgY3k9IjM1IiByPSI2IiBmaWxsPSIjMDUwODEwIi8+PGNpcmNsZSBjeD0iNDYiIGN5PSIzNCIgcj0iMi41IiBmaWxsPSIjMDBlNWNjIi8+PGNpcmNsZSBjeD0iNzYiIGN5PSIzNCIgcj0iMi41IiBmaWxsPSIjMDBlNWNjIi8+PC9zdmc+
+      env:
+        - name: OPENCLAW_GATEWAY_TOKEN
+          required: false
+        - name: VLLM_API_KEY
+          required: false
+      templates:
+        - name: agent.yaml
+          content: '{"deploymentModel":"config-driven","description":"Open-source AI coding assistant based on OpenClaw with gateway-based model routing and multi-channel support.","displayName":"OpenClaw","env":{"optional":["OPENCLAW_GATEWAY_TOKEN","VLLM_API_KEY"],"required":[]},"framework":"openclaw","labels":["coding-agent","gateway"],"logo":"data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTIwIDEyMCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZGVmcz48bGluZWFyR3JhZGllbnQgaWQ9ImxvYnN0ZXItZ3JhZGllbnQiIHgxPSIwJSIgeTE9IjAlIiB4Mj0iMTAwJSIgeTI9IjEwMCUiPjxzdG9wIG9mZnNldD0iMCUiIHN0b3AtY29sb3I9IiNmZjRkNGQiLz48c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiM5OTFiMWIiLz48L2xpbmVhckdyYWRpZW50PjwvZGVmcz48cGF0aCBkPSJNNjAgMTAgQzMwIDEwIDE1IDM1IDE1IDU1IEMxNSA3NSAzMCA5NSA0NSAxMDAgTDQ1IDExMCBMNTUgMTEwIEw1NSAxMDAgQzU1IDEwMCA2MCAxMDIgNjUgMTAwIEw2NSAxMTAgTDc1IDExMCBMNzUgMTAwIEM5MCA5NSAxMDUgNzUgMTA1IDU1IEMxMDUgMzUgOTAgMTAgNjAgMTBaIiBmaWxsPSJ1cmwoI2xvYnN0ZXItZ3JhZGllbnQpIi8+PHBhdGggZD0iTTIwIDQ1IEM1IDQwIDAgNTAgNSA2MCBDMTAgNzAgMjAgNjUgMjUgNTUgQzI4IDQ4IDI1IDQ1IDIwIDQ1WiIgZmlsbD0idXJsKCNsb2JzdGVyLWdyYWRpZW50KSIvPjxwYXRoIGQ9Ik0xMDAgNDUgQzExNSA0MCAxMjAgNTAgMTE1IDYwIEMxMTAgNzAgMTAwIDY1IDk1IDU1IEM5MiA0OCA5NSA0NSAxMDAgNDVaIiBmaWxsPSJ1cmwoI2xvYnN0ZXItZ3JhZGllbnQpIi8+PHBhdGggZD0iTTQ1IDE1IFEzNSA1IDMwIDgiIHN0cm9rZT0iI2ZmNGQ0ZCIgc3Ryb2tlLXdpZHRoPSIzIiBzdHJva2UtbGluZWNhcD0icm91bmQiLz48cGF0aCBkPSJNNzUgMTUgUTg1IDUgOTAgOCIgc3Ryb2tlPSIjZmY0ZDRkIiBzdHJva2Utd2lkdGg9IjMiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIvPjxjaXJjbGUgY3g9IjQ1IiBjeT0iMzUiIHI9IjYiIGZpbGw9IiMwNTA4MTAiLz48Y2lyY2xlIGN4PSI3NSIgY3k9IjM1IiByPSI2IiBmaWxsPSIjMDUwODEwIi8+PGNpcmNsZSBjeD0iNDYiIGN5PSIzNCIgcj0iMi41IiBmaWxsPSIjMDBlNWNjIi8+PGNpcmNsZSBjeD0iNzYiIGN5PSIzNCIgcj0iMi41IiBmaWxsPSIjMDBlNWNjIi8+PC9zdmc+","name":"openclaw-agent"}'
+      customProperties:
+        deploymentModel:
+            metadataType: MetadataStringValue
+            string_value: "config-driven"
+    - name: opencode-agent
+      displayName: OpenCode
+      description: AI-powered terminal-based coding agent built on OpenCode for code generation, editing, and debugging tasks.
+      repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/opencode/templates/opencode_agent
       framework: opencode
+      labels:
+        - coding-agent
+        - cli
+      logo: data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nMjQwJyBoZWlnaHQ9JzMwMCcgdmlld0JveD0nMCAwIDI0MCAzMDAnIGZpbGw9J25vbmUnIHhtbG5zPSdodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2Zyc+PGcgY2xpcC1wYXRoPSd1cmwoI2NsaXAwXzE0MDFfODYyNzQpJz48bWFzayBpZD0nbWFzazBfMTQwMV84NjI3NCcgc3R5bGU9J21hc2stdHlwZTpsdW1pbmFuY2UnIG1hc2tVbml0cz0ndXNlclNwYWNlT25Vc2UnIHg9JzAnIHk9JzAnIHdpZHRoPScyNDAnIGhlaWdodD0nMzAwJz48cGF0aCBkPSdNMjQwIDBIMFYzMDBIMjQwVjBaJyBmaWxsPSd3aGl0ZScvPjwvbWFzaz48ZyBtYXNrPSd1cmwoI21hc2swXzE0MDFfODYyNzQpJz48cGF0aCBkPSdNMTgwIDI0MEg2MFYxMjBIMTgwVjI0MFonIGZpbGw9JyNDRkNFQ0QnLz48cGF0aCBkPSdNMTgwIDYwSDYwVjI0MEgxODBWNjBaTTI0MCAzMDBIMFYwSDI0MFYzMDBaJyBmaWxsPScjMjExRTFFJy8+PC9nPjwvZz48ZGVmcz48Y2xpcFBhdGggaWQ9J2NsaXAwXzE0MDFfODYyNzQnPjxyZWN0IHdpZHRoPScyNDAnIGhlaWdodD0nMzAwJyBmaWxsPSd3aGl0ZScvPjwvY2xpcFBhdGg+PC9kZWZzPjwvc3ZnPg==
+      env:
+        - name: API_KEY
+          required: true
+        - name: BASE_URL
+          required: true
+        - name: MODEL_NAME
+          required: true
+      templates:
+        - name: agent.yaml
+          content: '{"description":"AI-powered terminal-based coding agent built on OpenCode for code generation, editing, and debugging tasks.","displayName":"OpenCode","env":{"optional":[],"required":["API_KEY","BASE_URL","MODEL_NAME"]},"framework":"opencode","labels":["coding-agent","cli"],"logo":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nMjQwJyBoZWlnaHQ9JzMwMCcgdmlld0JveD0nMCAwIDI0MCAzMDAnIGZpbGw9J25vbmUnIHhtbG5zPSdodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2Zyc+PGcgY2xpcC1wYXRoPSd1cmwoI2NsaXAwXzE0MDFfODYyNzQpJz48bWFzayBpZD0nbWFzazBfMTQwMV84NjI3NCcgc3R5bGU9J21hc2stdHlwZTpsdW1pbmFuY2UnIG1hc2tVbml0cz0ndXNlclNwYWNlT25Vc2UnIHg9JzAnIHk9JzAnIHdpZHRoPScyNDAnIGhlaWdodD0nMzAwJz48cGF0aCBkPSdNMjQwIDBIMFYzMDBIMjQwVjBaJyBmaWxsPSd3aGl0ZScvPjwvbWFzaz48ZyBtYXNrPSd1cmwoI21hc2swXzE0MDFfODYyNzQpJz48cGF0aCBkPSdNMTgwIDI0MEg2MFYxMjBIMTgwVjI0MFonIGZpbGw9JyNDRkNFQ0QnLz48cGF0aCBkPSdNMTgwIDYwSDYwVjI0MEgxODBWNjBaTTI0MCAzMDBIMFYwSDI0MFYzMDBaJyBmaWxsPScjMjExRTFFJy8+PC9nPjwvZz48ZGVmcz48Y2xpcFBhdGggaWQ9J2NsaXAwXzE0MDFfODYyNzQnPjxyZWN0IHdpZHRoPScyNDAnIGhlaWdodD0nMzAwJyBmaWxsPSd3aGl0ZScvPjwvY2xpcFBhdGg+PC9kZWZzPjwvc3ZnPg==","name":"opencode-agent"}'

--- a/data/redhat-agents-catalog.yaml
+++ b/data/redhat-agents-catalog.yaml
@@ -4412,6 +4412,1059 @@ agents:
     - name: claude-code-agent
       displayName: Claude Code
       description: Anthropic's Claude Code CLI for AI-powered code generation, editing, and debugging tasks.
+      readme: |
+        # Claude Code on OpenShift
+
+        A guide to deploying Claude Code as a containerized agent on Red Hat OpenShift. Supports four backend configurations: Anthropic API, Google Vertex AI, vLLM direct, and vLLM via OGX gateway.
+
+        ## Table of Contents
+
+        - [Licensing Notice](#licensing-notice)
+        - [Prerequisites](#prerequisites)
+        - [Step 1: Build the Container Image](#step-1-build-the-container-image)
+        - [Step 2: Create an OpenShift Project](#step-2-create-an-openshift-project)
+        - [Step 3: Choose Your Backend](#step-3-choose-your-backend)
+          - [Option A: Anthropic API](#option-a-anthropic-api)
+          - [Option B: Vertex AI](#option-b-vertex-ai)
+          - [Option C: vLLM Direct](#option-c-vllm-direct)
+          - [Option D: vLLM via OGX Gateway](#option-d-vllm-via-ogx-gateway)
+        - [Using Claude Code](#using-claude-code)
+        - [Configuration](#configuration)
+        - [MLflow Tracing (Optional)](#mlflow-tracing-optional)
+        - [Security Considerations](#security-considerations)
+        - [Troubleshooting](#troubleshooting)
+        - [Cleanup](#cleanup)
+        - [Known Limitations](#known-limitations)
+
+        ---
+
+        ## Licensing Notice
+
+        **Do not redistribute built container images.** The Containerfile installs Claude Code at build time via Anthropic's native installer. The resulting image contains Anthropic's proprietary binary, which is subject to their [commercial terms](https://code.claude.com/docs/en/legal-and-compliance) ("All rights reserved"). Building the image yourself for internal use is permitted, but redistributing the built image (e.g., pushing to a public registry) is not authorized.
+
+        ---
+
+        ## Prerequisites
+
+        - `podman` installed locally (on macOS, also run `podman machine init` and `podman machine start`)
+        - `oc` CLI installed and logged into your OpenShift cluster
+        - An Anthropic API key, a GCP service account key for Vertex AI, or a vLLM/OGX endpoint (no Anthropic credentials needed for self-hosted models)
+
+        All shell commands in this guide assume you are in the `deployment/` subdirectory, where the Containerfile and deployment manifests live:
+
+        ```bash
+        cd deployment/
+        ```
+
+        ---
+
+        ## Step 1: Build the Container Image
+
+        ```bash
+        podman build -t claude-code:latest -f Containerfile .
+
+        # Build with a specific version
+        podman build --build-arg CLAUDE_CODE_VERSION=2.1.123 -t claude-code:2.1.123 -f Containerfile .
+        ```
+
+        To verify the build locally, see the local test command in your chosen backend option below.
+
+        ---
+
+        ## Step 2: Create an OpenShift Project
+
+        ```bash
+        oc new-project my-claude-project
+        ```
+
+        ---
+
+        ## Step 3: Choose Your Backend
+
+        Follow **one** option below, then continue to [Using Claude Code](#using-claude-code).
+
+        | Option | Backend | Manifest | Deployment Name |
+        |--------|---------|----------|-----------------|
+        | [A](#option-a-anthropic-api) | Anthropic API | `deployment.yaml` | `claude-code` |
+        | [B](#option-b-vertex-ai) | Google Vertex AI | `deployment-vertex.yaml` | `claude-code-vertex` |
+        | [C](#option-c-vllm-direct) | vLLM Direct | `deployment-vllm.yaml` | `claude-code-vllm` |
+        | [D](#option-d-vllm-via-ogx-gateway) | vLLM via OGX | `deployment-ogx-vllm.yaml` | `claude-code-ogx-vllm` |
+
+        ---
+
+        ### Option A: Anthropic API
+
+        #### Get your API key
+
+        1. Go to [console.anthropic.com](https://console.anthropic.com/)
+        2. Sign in or create an account
+        3. Navigate to **API Keys** and click **Create Key**
+        4. Copy the key (starts with `sk-ant-api03-...`)
+
+        You need a paid account with credits.
+
+        #### Local test (optional)
+
+        ```bash
+        podman run --rm \
+          -e ANTHROPIC_API_KEY="sk-ant-api03-YOUR_KEY_HERE" \
+          claude-code:latest \
+          claude -p "What is 2+2?"
+        ```
+
+        #### Deploy
+
+        ```bash
+        # Create secret
+        oc create secret generic claude-credentials \
+          --from-literal=ANTHROPIC_API_KEY="sk-ant-api03-YOUR_KEY_HERE"
+
+        # Apply manifest and build
+        oc apply -f deployment.yaml
+        oc start-build claude-code --from-dir=. --follow
+
+        # Wait and test
+        oc rollout status deployment/claude-code
+        oc exec deployment/claude-code -- bash -c '
+          ~/.claude/claude-run -p "What is 2+2?"
+        '
+        ```
+
+        ---
+
+        ### Option B: Vertex AI
+
+        #### Get your GCP credentials
+
+        You need a GCP service account with Vertex AI access.
+
+        **Option 1: GCP Console**
+
+        1. Go to [GCP Console](https://console.cloud.google.com)
+        2. Select your project (Vertex AI API must be enabled)
+        3. Navigate to **IAM & Admin > Service Accounts**
+        4. Click **+ CREATE SERVICE ACCOUNT**
+           - Name: `claude-code-user`
+           - Grant role: **Vertex AI User** (`roles/aiplatform.user`)
+        5. Click the service account > **Keys** tab
+        6. Click **Add Key > Create new key > JSON**
+        7. Save the downloaded key file
+
+        Creating service accounts requires **IAM Admin** or **Service Account Admin** permissions.
+
+        **Option 2: gcloud CLI**
+
+        ```bash
+        gcloud iam service-accounts create claude-code-user \
+          --display-name="Claude Code User"
+
+        gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
+          --member="serviceAccount:claude-code-user@YOUR_PROJECT_ID.iam.gserviceaccount.com" \
+          --role="roles/aiplatform.user"
+
+        gcloud iam service-accounts keys create ~/claude-vertex-key.json \
+          --iam-account=claude-code-user@YOUR_PROJECT_ID.iam.gserviceaccount.com
+        ```
+
+        **Alternative: Application Default Credentials (ADC)**
+
+        If you already have credentials via `gcloud auth application-default login`, you can use your ADC file (typically at `~/.config/gcloud/application_default_credentials.json`) in place of a service account key. ADC credentials are user-scoped and typically carry broader permissions. Use ADC for local development only; for shared clusters, create a dedicated service account.
+
+        #### Local test (optional)
+
+        ```bash
+        podman run --rm \
+          -e CLAUDE_CODE_USE_VERTEX=1 \
+          -e ANTHROPIC_VERTEX_PROJECT_ID="your-gcp-project-id" \
+          -e CLOUD_ML_REGION="global" \
+          -e GOOGLE_APPLICATION_CREDENTIALS="/var/secrets/google/key.json" \
+          -v /path/to/your-service-account-key.json:/var/secrets/google/key.json:ro,z \
+          claude-code:latest \
+          claude -p "What is 2+2?"
+        ```
+
+        #### Deploy
+
+        ```bash
+        # Create secret
+        oc create secret generic claude-vertex-credentials \
+          --from-file=key.json=/path/to/your-service-account-key.json
+
+        # Apply manifest
+        oc apply -f deployment-vertex.yaml
+
+        # Patch ConfigMap with your project details
+        oc patch configmap claude-vertex-config \
+          -p '{"data":{"ANTHROPIC_VERTEX_PROJECT_ID":"your-gcp-project-id","CLOUD_ML_REGION":"global"}}'
+
+        # Build and deploy
+        oc start-build claude-code --from-dir=. --follow
+        oc rollout restart deployment/claude-code-vertex
+        oc rollout status deployment/claude-code-vertex
+
+        # Test
+        oc exec deployment/claude-code-vertex -- bash -c '
+          ~/.claude/claude-run -p "What is 2+2?"
+        '
+        ```
+
+        **Model selection:** On Vertex AI, the default `sonnet` model alias may resolve to an older model than on the direct Anthropic API. To use a specific version:
+
+        ```bash
+        oc set env deployment/claude-code-vertex CLAUDE_MODEL=claude-sonnet-4-6
+        ```
+
+        ---
+
+        ### Option C: vLLM Direct
+
+        Connects Claude Code directly to a vLLM server's `/v1/messages` endpoint.
+
+        ```text
+        Claude Code pod  ──HTTP──>  vLLM server (/v1/messages)
+        ```
+
+        #### Prerequisites
+
+        - A vLLM server with `/v1/messages` endpoint support. If you need to deploy one, see [vllm/README.md](vllm/README.md).
+        - **Context window**: minimum 32K tokens (Claude Code's system prompt is ~23K). For realistic coding work, **128K+ is strongly recommended** since CLAUDE.md, skills, file listings, and conversation easily push past 100K tokens.
+        - Network connectivity from your OpenShift cluster to the vLLM server. See [Network Connectivity](#network-connectivity-vllmogx) in Troubleshooting if the server is outside the cluster.
+
+        **Model quality note:** Claude Code is designed for Anthropic's Claude models. Open source models may produce lower quality results, particularly for complex multi-step tasks. Including language runtimes in the container (see [Extending the Container Image](#extending-the-container-image)) helps because the agent can run tests and catch its own mistakes.
+
+        #### Edit the deployment manifest
+
+        Edit `deployment-vllm.yaml`. Search for placeholder values and replace them:
+
+        - `ANTHROPIC_BASE_URL`: Your vLLM server's base URL, for example:
+          - `http://my-vllm-service.namespace.svc.cluster.local` (cluster-internal)
+          - `https://vllm.apps.cluster.example.com` (external route)
+
+        Replace model IDs in the **ConfigMap** and the **Deployment** env vars. If your vLLM server hosts only one model, use the same model ID everywhere. If it hosts multiple models, you can assign different models to each role (e.g., a small fast model for haiku, a mid-range model for sonnet, and your most capable model for opus).
+
+        | Variable | Purpose | Example (single model) |
+        |----------|---------|----------------------|
+        | ConfigMap `"model"` | Default model in `settings.json` | `gpt-oss-120b` |
+        | `CLAUDE_MODEL` | Main conversation model (overrides ConfigMap) | `gpt-oss-120b` |
+        | `ANTHROPIC_CUSTOM_MODEL_OPTION` | Adds model to the interactive mode picker menu | `gpt-oss-120b` |
+        | `ANTHROPIC_DEFAULT_HAIKU_MODEL` | What the `haiku` alias resolves to (used for background tasks like summarization) | `gpt-oss-120b` |
+        | `ANTHROPIC_DEFAULT_SONNET_MODEL` | What the `sonnet` alias resolves to (selectable via `/model sonnet`) | `gpt-oss-120b` |
+        | `ANTHROPIC_DEFAULT_OPUS_MODEL` | What the `opus` alias resolves to (selectable via `/model opus`, used for plan mode) | `gpt-oss-120b` |
+
+        The three alias overrides are required. Without them, Claude Code tries to resolve haiku, sonnet, and opus to Anthropic model names (e.g., `claude-haiku-4-5-20251001`), which don't exist on vLLM, causing 404 errors.
+
+        #### Context window configuration
+
+        Claude Code defaults to a 180K context window, which causes failures on models with smaller windows. Configure these env vars in the deployment manifest:
+
+        - `CLAUDE_CODE_AUTO_COMPACT_WINDOW`: Your model's context window in tokens (e.g., `131072`). Do not pre-subtract output tokens.
+        - `CLAUDE_CODE_MAX_OUTPUT_TOKENS`: Output budget (e.g., `28000`).
+        - `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE`: Autocompaction threshold. Formula: `percentage <= (context_window - max_output_tokens) / context_window * 100`
+
+        | Model | Context | AUTO_COMPACT_WINDOW | MAX_OUTPUT_TOKENS | AUTOCOMPACT_PCT |
+        |-------|---------|--------------------|--------------------|-----------------|
+        | *(32K minimum example)* | 32K | 32768 | 4000 | 85 |
+        | RedHatAI/Qwen3.6-35B-A3B-NVFP4 | 131K | 131072 | 28000 | 75 |
+        | Qwen/Qwen3-235B-A22B | 131K | 131072 | 28000 | 75 |
+        | openai/gpt-oss-120b | 131K | 131072 | 28000 | 75 |
+        | ibm-granite/granite-4.1-8b-instruct | 524K | 524288 | 64000 | 83 |
+        | meta-llama/Llama-4-Maverick-17B-128E | 1,048K | 1048576 | 64000 | 83 |
+
+        Models with 500K+ context can use the default 83% threshold. Models with smaller context windows need a lower percentage to leave sufficient headroom for output tokens. A 32K model is the minimum supported; expect frequent autocompaction and limited conversation depth at this size.
+
+        #### Local test (optional)
+
+        ```bash
+        podman run --rm \
+          -e ANTHROPIC_BASE_URL="https://YOUR_VLLM_ENDPOINT" \
+          -e ANTHROPIC_AUTH_TOKEN="fake" \
+          claude-code:latest \
+          claude --model YOUR_MODEL_ID -p "What is 2+2?"
+        ```
+
+        #### Deploy
+
+        ```bash
+        oc apply -f deployment-vllm.yaml
+        oc start-build claude-code --from-dir=. --follow
+        oc rollout status deployment/claude-code-vllm
+
+        oc exec deployment/claude-code-vllm -- bash -c '
+          ~/.claude/claude-run -p "What is 2+2?"
+        '
+        ```
+
+        ---
+
+        ### Option D: vLLM via OGX Gateway
+
+        Uses OGX (from RHOAI) as an API gateway between Claude Code and vLLM.
+
+        ```text
+        Claude Code pod  ──HTTP──>  OGX (API Gateway)  ──HTTP──>  vLLM server
+        ```
+
+        #### Prerequisites
+
+        - OGX deployed and serving `GET /v1/health`, `GET /v1/models`, and `POST /v1/messages`. See [`ogx/README.md`](ogx/README.md) for one standalone deployment pattern, or reuse an existing OGX endpoint in your cluster.
+        - A vLLM server accessible from OGX.
+        - **Context window**: minimum 32K tokens. **128K+ strongly recommended** for realistic coding work.
+
+        **Model quality note:** Claude Code is designed for Anthropic's Claude models. Open source models may produce lower quality results, particularly for complex multi-step tasks. Including language runtimes in the container (see [Extending the Container Image](#extending-the-container-image)) helps because the agent can run tests and catch its own mistakes.
+
+        #### Edit the deployment manifest
+
+        Edit `deployment-ogx-vllm.yaml`. Search for placeholder values and replace them:
+
+        - `ANTHROPIC_BASE_URL`: Your OGX route URL (replace `YOUR_OGX_URL`)
+
+        Replace model IDs in the **ConfigMap** and the **Deployment** env vars. OGX uses the `vllm/` prefix to route requests to the vLLM backend, so all model IDs must use the exact `vllm/<model-id>` value returned by `GET /v1/models`. If OGX serves only one model, use the same value everywhere. If it serves multiple models, you can assign different models to each role.
+
+        | Variable | Purpose | Example (single model) |
+        |----------|---------|----------------------|
+        | ConfigMap `"model"` | Default model in `settings.json` | `vllm/gpt-oss-120b` |
+        | `CLAUDE_MODEL` | Main conversation model (overrides ConfigMap) | `vllm/gpt-oss-120b` |
+        | `ANTHROPIC_CUSTOM_MODEL_OPTION` | Adds model to the interactive mode picker menu | `vllm/gpt-oss-120b` |
+        | `ANTHROPIC_DEFAULT_HAIKU_MODEL` | What the `haiku` alias resolves to (used for background tasks like summarization) | `vllm/gpt-oss-120b` |
+        | `ANTHROPIC_DEFAULT_SONNET_MODEL` | What the `sonnet` alias resolves to (selectable via `/model sonnet`) | `vllm/gpt-oss-120b` |
+        | `ANTHROPIC_DEFAULT_OPUS_MODEL` | What the `opus` alias resolves to (selectable via `/model opus`, used for plan mode) | `vllm/gpt-oss-120b` |
+
+        The three alias overrides are required. Without them, Claude Code tries to resolve haiku, sonnet, and opus to Anthropic model names, causing 404 errors.
+
+        #### Deploy
+
+        ```bash
+        oc apply -f deployment-ogx-vllm.yaml
+        oc start-build claude-code --from-dir=. --follow
+        oc rollout status deployment/claude-code-ogx-vllm
+
+        oc exec deployment/claude-code-ogx-vllm -- bash -c '
+          ~/.claude/claude-run -p "What is 2+2?"
+        '
+        ```
+
+        ---
+
+        ## Using Claude Code
+
+        The examples below use `claude-code` as the deployment name. Substitute the name from the [backend table](#step-3-choose-your-backend) if you chose a different option.
+
+        ### Running Prompts
+
+        The `claude-run` wrapper includes all container-configured arguments (permission bypass, MCP config, model selection):
+
+        ```bash
+        oc exec deployment/claude-code -- bash -c '
+          ~/.claude/claude-run -p "Your prompt here"
+        '
+        ```
+
+        You can also source the environment directly:
+
+        ```bash
+        oc exec deployment/claude-code -- bash -c '
+          source ~/.claude/env.sh
+          claude $CLAUDE_EXTRA_ARGS -p "Your prompt here"
+        '
+        ```
+
+        ### Interactive Mode
+
+        For multi-turn conversations with a TTY:
+
+        ```bash
+        # OpenShift
+        oc exec -it deployment/claude-code -- bash -c '
+          ~/.claude/claude-run
+        '
+
+        # Local (example with Anthropic API; substitute env vars for your backend)
+        podman run -it --rm \
+          -e ANTHROPIC_API_KEY="sk-ant-api03-YOUR_KEY_HERE" \
+          -v $(pwd):/workspace:z \
+          claude-code:latest \
+          claude
+        ```
+
+        Interactive mode requires the `-it` flags for both `podman` and `oc exec`.
+
+        ### Debug Mode
+
+        ```bash
+        # Full debug logging
+        oc exec -it deployment/claude-code -- bash -c 'claude --debug'
+
+        # API calls only
+        oc exec -it deployment/claude-code -- bash -c 'claude --debug api'
+        ```
+
+        Debug logs are written to a file. To tail them in real time from a second terminal:
+
+        ```bash
+        oc exec deployment/claude-code -- bash -c 'tail -f /home/claude-agent/.claude/debug/*.txt'
+        ```
+
+        ### Retrieving Files from the Container
+
+        When Claude Code generates files (reports, documents, code) that you want locally without pushing to Git, use `oc cp`:
+
+        ```bash
+        # Copy a single file
+        oc cp <pod-name>:/workspace/projects/report.md ./report.md
+
+        # Copy a directory
+        oc cp <pod-name>:/workspace/projects/output/ ./output/
+
+        # Find the pod name
+        oc get pods -l app=claude-code -o name
+
+        # List files in the container
+        oc exec deployment/claude-code -- ls -la /workspace/projects/
+        ```
+
+        ### Rebuilding the Image
+
+        After modifying the Containerfile or entrypoint, rebuild and update the deployment:
+
+        ```bash
+        # Build and push the new image
+        oc start-build claude-code --from-dir=. --follow
+
+        # Update the deployment to use the new image
+        oc set image deployment/<your-deployment-name> \
+          claude-code=$(oc get istag claude-code:latest -o jsonpath='{.image.dockerImageReference}')
+        ```
+
+        `oc rollout restart` alone is not sufficient. OpenShift pins deployments to a specific image digest, so restarting just recreates the pod with the old image. You must update the image reference with `oc set image` to pick up the new build.
+
+        ---
+
+        ## Configuration
+
+        ### Session Persistence
+
+        Session history and memory persist across pod restarts via the workspace PVC. The `CLAUDE_CONFIG_DIR` environment variable points to `/workspace/.claude/`.
+
+        **Directory structure:**
+
+        ```text
+        /workspace/                      <- PVC mount (persistent)
+        |-- .claude/                     <- Global config (CLAUDE_CONFIG_DIR)
+        |   |-- settings.json            <- Copied from ConfigMap at startup
+        |   |-- skills/                  <- ConfigMap mount
+        |   |-- memory/                  <- Persisted (global memory)
+        |   +-- projects/                <- Persisted (session history)
+        +-- projects/                    <- Working directory (where users run Claude)
+            +-- .claude/                 <- Local auto-memory (separate from global)
+        ```
+
+        This structure separates global config (`/workspace/.claude/`) from local auto-memory (`/workspace/projects/.claude/`), mirroring the experience of running Claude Code locally.
+
+        **What persists:**
+
+        | Data | Location | Persisted? |
+        |------|----------|------------|
+        | Session history | `/workspace/.claude/projects/` | Yes |
+        | Global memory | `/workspace/.claude/memory/` | Yes |
+        | Local auto-memory | `/workspace/projects/.claude/` | Yes |
+        | Project files | `/workspace/projects/` | Yes |
+        | Skills | `/etc/claude-skills/` (symlinked to `$CLAUDE_CONFIG_DIR/skills/`) | ConfigMap (re-mounted each restart) |
+        | Settings | `${CLAUDE_CONFIG_DIR}/settings.json` | Copied from ConfigMap on first start |
+
+        The entrypoint creates a symlink `~/.claude` -> `/workspace/.claude/` so that standard `~/.claude/` paths work as expected.
+
+        **Disabling persistence:** Set `CLAUDE_CONFIG_DIR` to a non-PVC path:
+
+        ```yaml
+        env:
+          - name: CLAUDE_CONFIG_DIR
+            value: "/tmp/.claude"
+        ```
+
+        ### Injecting Skills
+
+        Skills extend Claude Code with custom instructions. They are auto-discovered from `~/.claude/skills/`. The skills ConfigMap is mounted at `/etc/claude-skills/` and the entrypoint symlinks it into `$CLAUDE_CONFIG_DIR/skills/`. Each skill must be in a subdirectory containing a `SKILL.md` file.
+
+        **Upgrading from older deployments:** If your PVC has an existing `skills/` directory from a previous deployment, the entrypoint automatically moves it to `skills.bak/` before creating the symlink.
+
+        **1. Create a SKILL.md file:**
+
+        ```markdown
+        # Code Review
+
+        When reviewing code, analyze for:
+
+        1. **Correctness** - Logic errors, edge cases, off-by-one errors
+        2. **Security** - Input validation, injection risks, hardcoded secrets
+        3. **Performance** - Unnecessary loops, N+1 queries, missing indexes
+
+        Provide feedback as:
+        - **Must Fix** - Bugs or security issues
+        - **Should Fix** - Performance or maintainability concerns
+        - **Consider** - Style suggestions or minor improvements
+        ```
+
+        **2. Create a ConfigMap from your skill files:**
+
+        ```bash
+        oc create configmap <skills-configmap-name> \
+          --from-file=code-review-skill=./skills/code-review/SKILL.md
+        ```
+
+        The ConfigMap name must match your deployment manifest (e.g., `claude-skills`, `claude-vllm-skills`).
+
+        **3. Add an `items` mapping to the skills volume in your deployment manifest:**
+
+        The `items` mapping is required so Kubernetes creates the `<skill-name>/SKILL.md` subdirectory structure that Claude Code expects. Without it, the file appears as a flat file and won't be discovered.
+
+        ```yaml
+        volumes:
+          - name: skills
+            configMap:
+              name: <skills-configmap-name>
+              optional: true
+              items:
+                - key: code-review-skill
+                  path: code-review/SKILL.md
+        ```
+
+        Each `items` entry maps a ConfigMap key to a path under the mount point. For multiple skills, add one entry per skill. For many skills, consider a PVC instead of a ConfigMap.
+
+        ### MCP Server Configuration
+
+        MCP (Model Context Protocol) servers extend Claude Code with additional tools. Configure via mounted config file or environment variable.
+
+        **Config file format:**
+
+        ```json
+        {
+          "mcpServers": {
+            "remote-api": {
+              "type": "http",
+              "url": "https://mcp.example.com/v1",
+              "headers": {
+                "Authorization": "Bearer ${API_TOKEN}"
+              }
+            },
+            "local-tool": {
+              "command": "/usr/bin/my-tool",
+              "args": ["--flag"],
+              "env": {
+                "TOOL_CONFIG": "/etc/tool.conf"
+              }
+            }
+          }
+        }
+        ```
+
+        **GitHub MCP example** (requires a [Personal Access Token](https://github.com/settings/tokens)). The `${GITHUB_PAT}` variable is expanded at runtime from the container's environment; inject it via a Kubernetes Secret (see below):
+
+        ```json
+        {
+          "mcpServers": {
+            "github": {
+              "type": "http",
+              "url": "https://api.githubcopilot.com/mcp/",
+              "headers": {
+                "Authorization": "Bearer ${GITHUB_PAT}"
+              }
+            }
+          }
+        }
+        ```
+
+        **Injecting secrets:** Environment variables like `${API_TOKEN}` can be injected via Kubernetes Secrets in the Deployment env section:
+
+        ```yaml
+        env:
+          - name: API_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: mcp-credentials
+                key: token
+        ```
+
+        Avoid hardcoding credentials in ConfigMap JSON.
+
+        **Transport types:**
+
+        | Type | Use case | Requirements |
+        |------|----------|--------------|
+        | `http` | Remote MCP servers (recommended) | Network access to endpoint |
+        | `sse` | Legacy remote servers | Network access to endpoint |
+        | `command` | Local process-based servers | Executable must exist in container |
+
+        The base image includes `git`, `curl`, `jq`, `bash`, and `python3`. Command-based MCP servers requiring `npx` or other runtimes need a custom image (see [Extending the Container Image](#extending-the-container-image)).
+
+        **Option 1: Mounted config file.** The manifests mount a ConfigMap to `/etc/mcp/config.json`. Update the ConfigMap (name varies by deployment: `claude-mcp-config`, `claude-vertex-mcp-config`, `claude-vllm-mcp-config`, or `claude-ogx-vllm-mcp-config`):
+
+        ```bash
+        oc patch configmap claude-mcp-config -p '{
+          "data": {
+            "config.json": "{\"mcpServers\":{\"my-api\":{\"type\":\"http\",\"url\":\"https://mcp.example.com/v1\"}}}"
+          }
+        }'
+        oc rollout restart deployment/claude-code
+        ```
+
+        **Option 2: Environment variable.** Set `MCP_CONFIG_JSON` with inline JSON in the Deployment spec:
+
+        ```yaml
+        - name: MCP_CONFIG_JSON
+          value: '{"mcpServers":{"my-api":{"type":"http","url":"https://mcp.example.com/v1"}}}'
+        ```
+
+        ### Workspace Instructions (CLAUDE.md)
+
+        Mount a `CLAUDE.md` file to the workspace directory to inject project-specific instructions:
+
+        ```bash
+        oc create configmap claude-workspace-instructions \
+          --from-file=CLAUDE.md=./CLAUDE.md
+        ```
+
+        Add to the deployment manifest:
+
+        ```yaml
+        # volumeMounts section:
+        - name: workspace-instructions
+          mountPath: /workspace/CLAUDE.md
+          subPath: CLAUDE.md
+          readOnly: true
+
+        # volumes section:
+        - name: workspace-instructions
+          configMap:
+            name: claude-workspace-instructions
+        ```
+
+        Claude Code automatically reads CLAUDE.md from the working directory and applies the instructions to the session.
+
+        ### Overriding settings.json
+
+        All manifests include a settings ConfigMap staged at a read-only path (`/etc/claude-config/settings.json`). On first start, the entrypoint copies it to `${CLAUDE_CONFIG_DIR}/settings.json` on the writable PVC. On subsequent restarts, the existing file is preserved so that runtime changes (e.g., hooks added by `mlflow autolog`) survive. To force a settings reset, delete the file from the PVC before restarting. The ConfigMap name varies by deployment (`claude-settings`, `claude-vertex-settings`, `claude-vllm-settings`, or `claude-ogx-vllm-settings`):
+
+        ```bash
+        oc patch configmap claude-settings -p '{
+          "data": {
+            "settings.json": "{\n  \"model\": \"your-model-id\"\n}"
+          }
+        }'
+        oc rollout restart deployment/claude-code
+        ```
+
+        Or edit the ConfigMap in the manifest YAML before applying:
+
+        ```yaml
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: claude-settings
+        data:
+          settings.json: |
+            {
+              "model": "your-model-id"
+            }
+        ```
+
+        ### Extending the Container Image
+
+        The base image includes `git`, `curl`, `jq`, `bash`, and `python3`. For real coding workflows, add language runtimes so the agent can run tests, lint, and build. Including the runtimes your project uses significantly improves agent output quality since the agent can run tests and catch its own mistakes.
+
+        The following example adds common development tools. Remove any you don't need:
+
+        ```dockerfile
+        # In the "Install System Dependencies" section of the Containerfile
+        RUN microdnf install -y --nodocs \
+                git \
+                curl \
+                jq \
+                python3.12 \
+                python3.12-pip \
+                # Build tools
+                make \
+                gcc \
+                tar \
+                unzip \
+                patch \
+                diffutils \
+                which \
+                # Node.js (includes npm)
+                nodejs \
+                # Go
+                golang \
+                # Java
+                java-21-openjdk-devel \
+                maven \
+                # Rust
+                rust \
+                cargo \
+            && microdnf clean all \
+            && rm -rf /var/cache/yum
+        ```
+
+        The GitHub CLI (`gh`) is not available in UBI repos and must be installed separately:
+
+        ```dockerfile
+        # Install GitHub CLI
+        ARG GH_VERSION=2.74.1
+        RUN curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+            | tar -xz -C /usr/local/bin --strip-components=2 "gh_${GH_VERSION}_linux_amd64/bin/gh"
+        ```
+
+        ---
+
+        ## MLflow Tracing (Optional)
+
+        The container image includes MLflow 3.12 with the `kubernetes-namespaced` auth plugin, and the entrypoint automatically configures tracing when `MLFLOW_TRACKING_URI` is set. No changes to the Containerfile or entrypoint are needed.
+
+        ### Prerequisites
+
+        - An MLflow instance running on your RHOAI cluster with a workspace matching your namespace.
+
+        ### 1. Grant RBAC
+
+        ```bash
+        oc adm policy add-role-to-user edit -z default -n <your-namespace>
+        ```
+
+        For production, use a dedicated service account with least-privilege RBAC scoped to the permissions MLflow's `kubernetes-namespaced` auth plugin requires.
+
+        ### 2. Add MLflow env vars to your deployment manifest
+
+        Uncomment the MLflow env vars in your deployment manifest (all four manifests include commented-out placeholders), or add these to the `env` section:
+
+        ```yaml
+        - name: MLFLOW_TRACKING_URI
+          value: "https://mlflow.<rhoai-namespace>.svc:8443/mlflow"
+        - name: MLFLOW_TRACKING_AUTH
+          value: "kubernetes-namespaced"
+        - name: MLFLOW_WORKSPACE
+          value: "<your-namespace>"
+        - name: MLFLOW_EXPERIMENT_NAME
+          value: "claude-code-traces"
+        - name: MLFLOW_TRACKING_INSECURE_TLS
+          value: "true"  # dev/test only; production should use proper TLS certificates
+        ```
+
+        The `<rhoai-namespace>` is commonly `redhat-ods-applications`. The `/mlflow` path suffix is required for MLflow 3.12+.
+
+        If your deployment is already running, re-apply the manifest and restart the pod to pick up the new env vars:
+
+        ```bash
+        oc apply -f <your-deployment-manifest>.yaml
+        oc rollout restart deployment/<deployment-name>
+        ```
+
+        ### 3. Verify
+
+        ```bash
+        # Check startup logs for MLflow initialization
+        oc logs deployment/<deployment-name> | grep -i mlflow
+
+        # Run a test prompt
+        oc exec deployment/<deployment-name> -- bash -c '
+          ~/.claude/claude-run -p "What is 2+2?"
+        '
+
+        # Check your MLflow UI for a new trace under the experiment name
+        ```
+
+        ### 4. View traces in the MLflow UI
+
+        Find the MLflow UI URL from the ConsoleLink:
+
+        ```bash
+        oc get consolelink mlflow -o jsonpath='{.spec.href}'
+        ```
+
+        This typically returns a URL through the RHOAI data science gateway (e.g., `https://rh-ai.<cluster-domain>/mlflow`). Open that URL in your browser and log in with the same OpenShift identity that deployed the agent. The MLflow workspace maps to the Kubernetes namespace, so you must have RBAC access to the agent's namespace to see its experiments and traces.
+
+        After login, select your workspace (the namespace name, e.g., `my-claude-code`) and navigate to the experiment you configured in `MLFLOW_EXPERIMENT_NAME`.
+
+        > **Note:** The direct MLflow route (`mlflow-<rhoai-namespace>.<cluster-domain>`) does not handle browser authentication. Always use the gateway URL from the ConsoleLink, which routes through OAuth.
+
+        ### What gets traced
+
+        Each session captures tool call sequences, token counts (input/output/total), session duration, model name, and status as OTel spans. The stop-hook fires after the session ends, so there is zero impact on agent response times. The trace schema works identically across all four backends.
+
+        ### MLflow version options
+
+        The default Containerfile uses MLflow 3.12 with a Python hook. MLflow 3.14+ also supports an npm plugin approach — uncomment the npm plugin env var in your deployment manifest to enable it. The plugin must be built from [upstream master](https://github.com/mlflow/mlflow/tree/master/libs/typescript) until the next plugin release syncs the fix. See [mlflow-tracing.md](mlflow-tracing.md) for a comparison of both approaches.
+
+        > **TLS note:** The npm plugin currently requires `NODE_TLS_REJECT_UNAUTHORIZED=0` or `NODE_EXTRA_CA_CERTS` for clusters with non-public TLS certificates. Both are process-wide Node.js settings. Upstream work is in progress to support `MLFLOW_TRACKING_INSECURE_TLS` and `MLFLOW_TRACKING_SERVER_CERT_PATH` scoped to MLflow connections only ([mlflow#24140](https://github.com/mlflow/mlflow/issues/24140)). Kubernetes-native auth (`MLFLOW_TRACKING_AUTH`) is also being added to the TypeScript SDK ([mlflow#24141](https://github.com/mlflow/mlflow/issues/24141)).
+
+        For detailed tracing investigation results and benchmark data, see [mlflow-tracing.md](mlflow-tracing.md).
+
+        ---
+
+        ## Security Considerations
+
+        ### SKIP_PERMISSIONS
+
+        The deployment manifests set `SKIP_PERMISSIONS=true` by default, passing `--dangerously-skip-permissions` to Claude Code. This disables all permission prompts, including file-system write confirmations and confirmation of destructive operations (e.g., `git push --force`).
+
+        **Why it's enabled by default:**
+
+        - The container runs as non-root with dropped capabilities and seccomp profiles
+        - Claude only has access to the isolated `/workspace` PVC, not host filesystems
+        - Permission prompts don't work well in non-interactive `oc exec` scenarios
+        - One of the main advantages of running Claude Code in an isolated container is enabling less-interrupted workflows
+
+        **Tradeoffs:** Running in an isolated container removes much of the reason you would normally keep permission checks in place: the container cannot access data that is not explicitly mounted into it. However, skipping permissions also disables guardrails against destructive operations on external services the agent can reach, such as force-pushing to a Git remote or making unintended API calls via MCP servers. If you are running interactively and want an extra layer of confirmation, you can disable `SKIP_PERMISSIONS`. But for headless or automated usage, permission prompts are not practical, and you should rely on the repository safeguards described below instead.
+
+        To disable, set `SKIP_PERMISSIONS=false` in the deployment manifest or remove the variable.
+
+        ### Repository Safeguards
+
+        When an AI agent has push access to a Git repository, ensure the repository has protections against mistakes. This is especially important with `SKIP_PERMISSIONS=true` and when using less capable models that are more likely to make errors such as committing directly to main, force-pushing, or merging their own PRs.
+
+        **Recommended protections:**
+
+        - **Branch protection rules**: Protect your main/default branch so direct pushes are blocked, forcing all changes through pull requests. On GitHub: Settings > Branches > Branch protection rules.
+        - **Required pull request reviews**: Require at least one approval from someone other than the PR author before merging. This prevents the agent from opening and immediately merging a PR without human review.
+        - **Limit PAT scope**: When creating the GitHub Personal Access Token used by the agent, grant only the minimum permissions needed. See [GitHub's documentation on token scopes](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) for fine-grained token options.
+        - **Status checks**: Require CI checks (tests, linting) to pass before a PR can be merged, so broken code cannot be merged even if a review is approved.
+
+        These protections apply regardless of whether you are using Claude Code or any other AI coding tool. They are standard best practices for collaborative development, but become critical when an automated agent has commit and push access.
+
+        ### Credential Isolation
+
+        When credentials such as GitHub PATs or API tokens are passed as environment variables or written to files inside the container, the agent can read them directly. This means the agent could inadvertently expose credentials in conversation output, commit messages, or through MCP server calls. This is a known limitation of the approach described in this guide.
+
+        For many use cases, this risk is acceptable when combined with the safeguards above: limiting PAT scope to the minimum required permissions, protecting branches, and requiring PR reviews. However, for environments with strict security requirements, the ideal approach is to isolate the agent from the credentials it depends on, so that it can use tools (like git push or GitHub APIs) without being able to see or exfiltrate the underlying secrets.
+
+        Container isolation solutions are actively exploring ways to provide this kind of separation. If credential isolation is a requirement for your deployment, consider evaluating such solutions as they mature.
+
+        ---
+
+        ## Troubleshooting
+
+        ### Network Connectivity (vLLM/OGX)
+
+        If the vLLM or OGX server is outside the cluster (e.g., on EC2 or another cloud), verify the pod can reach it:
+
+        ```bash
+        # Find the cluster's egress IP
+        oc exec deployment/claude-code-vllm -- curl -s ifconfig.me
+
+        # Test connectivity to the server
+        oc exec deployment/claude-code-vllm -- curl -s -o /dev/null -w "%{http_code}" http://YOUR_HOST:8000/v1/models
+        ```
+
+        Common causes of connection failure include security group rules, network policies, and firewalls. If the server uses IP-based access rules, add the cluster egress IP to the allow list (e.g., AWS security group inbound rule on TCP port 8000).
+
+        ### Context Window Errors
+
+        Models with insufficient context will fail with errors like:
+
+        ```text
+        API Error: 400 {"type":"error","error":{"type":"BadRequestError",
+        "message":"max_tokens must be at least 1, got -7214."}}
+        ```
+
+        This means the model's context window is too small to fit Claude Code's system prompt plus the requested output tokens. See [Context window configuration](#context-window-configuration) in Option C for how to configure the context window, autocompaction, and output budget.
+
+        ### OGX 404 Logs
+
+        When monitoring OGX logs, some 404 responses are normal:
+
+        ```bash
+        oc logs deployment/ogx --tail=50
+        ```
+
+        ```text
+        HEAD / 404        # Claude Code HTTP client probing
+        POST /v1/messages 404  # Initial probes (2x)
+        POST /v1/messages 200  # Successful request with "Using native /v1/messages passthrough"
+        ```
+
+        The 404s are caused by Claude Code's HTTP client probing behavior and do not indicate errors. The key indicator of success is seeing `Using native /v1/messages passthrough` followed by a 200 response.
+
+        ### Testing Endpoints Directly
+
+        To verify the vLLM or OGX server supports the Anthropic Messages API:
+
+        **vLLM:**
+
+        ```bash
+        # Health and model listing
+        curl -s "https://YOUR_VLLM_ENDPOINT/health"
+        curl -s "https://YOUR_VLLM_ENDPOINT/v1/models"
+
+        # Non-streaming request
+        curl -s -X POST "https://YOUR_VLLM_ENDPOINT/v1/messages" \
+          -H "Content-Type: application/json" \
+          -H "anthropic-version: 2023-06-01" \
+          -d '{
+            "model": "YOUR_MODEL_ID",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "What is 2+2? Reply with just the number."}]
+          }'
+
+        # Streaming request
+        curl -s -X POST "https://YOUR_VLLM_ENDPOINT/v1/messages" \
+          -H "Content-Type: application/json" \
+          -H "anthropic-version: 2023-06-01" \
+          -d '{
+            "model": "YOUR_MODEL_ID",
+            "max_tokens": 100,
+            "stream": true,
+            "messages": [{"role": "user", "content": "Say hello"}]
+          }'
+
+        # Tool calling (Claude Code uses tools extensively)
+        curl -s -X POST "https://YOUR_VLLM_ENDPOINT/v1/messages" \
+          -H "Content-Type: application/json" \
+          -H "anthropic-version: 2023-06-01" \
+          -d '{
+            "model": "YOUR_MODEL_ID",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "List files in the current directory"}],
+            "tools": [{"name": "bash", "description": "Run a bash command", "input_schema": {"type": "object", "properties": {"command": {"type": "string"}}, "required": ["command"]}}]
+          }'
+        ```
+
+        **OGX:** Use the same commands with your OGX route URL and the `vllm/` model prefix reported by `GET /v1/models`:
+
+        ```bash
+        OGX_URL=<your-ogx-route-host>
+        curl -s "https://$OGX_URL/v1/health"
+        curl -s "https://$OGX_URL/v1/models"
+
+        curl -s -X POST "https://$OGX_URL/v1/messages" \
+          -H "Content-Type: application/json" \
+          -H "anthropic-version: 2023-06-01" \
+          -d '{
+            "model": "vllm/YOUR_MODEL_ID",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "What is 2+2? Reply with just the number."}]
+          }'
+        ```
+
+        ### Model Aliasing
+
+        vLLM supports model aliasing via `--served-model-name`, letting you serve a model under a custom name without OGX:
+
+        ```yaml
+        command:
+          - python3
+          - -m
+          - vllm.entrypoints.openai.api_server
+          - --model
+          - openai/gpt-oss-120b
+          - --served-model-name
+          - my-custom-model-name
+        ```
+
+        Then set `CLAUDE_MODEL` on the Claude Code deployment to match:
+
+        ```bash
+        oc set env deployment/claude-code CLAUDE_MODEL=my-custom-model-name
+        ```
+
+        `--served-model-name` is a **replacement**, not an addition. The original HuggingFace model ID is no longer recognized after setting an alias. To keep both the original name and an alias, pass the flag twice: `--served-model-name openai/gpt-oss-120b --served-model-name my-alias`.
+
+        ### Interactive Wizard API Key Confirmation
+
+        When launching interactive mode, Claude Code's setup wizard includes an API key confirmation page. The behavior depends on which authentication env var you use:
+
+        - **`ANTHROPIC_AUTH_TOKEN`**: The key confirmation page is skipped entirely. This is what the vLLM and OGX manifests use. Set it to `"fake"` if your backend requires no authentication, or to a real token if it does.
+        - **`ANTHROPIC_API_KEY`**: The wizard prompts you to accept or reject the key. Use this for the Anthropic API (Option A) or any backend that requires an Anthropic-style API key. You must accept the key when prompted; see below for what happens if you reject it.
+
+        **If you reject an API key**, Claude Code stores the rejection in `/workspace/.claude/.claude.json` on the PVC and redirects you to browser-based authentication. Restarting the pod does not help because the rejection is persisted on the PVC. To recover, either fix the config file or delete the PVC and redeploy:
+
+        ```bash
+        # Option 1: Fix the config file
+        oc exec deployment/<your-deployment-name> -- python3 -c '
+        import json
+        f = "/workspace/.claude/.claude.json"
+        with open(f) as fh:
+            d = json.load(fh)
+        d["customApiKeyResponses"] = {"approved": [], "rejected": []}
+        with open(f, "w") as fh:
+            json.dump(d, fh, indent=2)
+        print("Fixed: cleared key rejections")
+        '
+
+        # Option 2: Delete PVC and redeploy (full fresh start)
+        oc delete pvc <your-workspace-pvc>
+        oc rollout restart deployment/<your-deployment-name>
+        ```
+
+        ### Test Scripts
+
+        For automated validation of vLLM endpoints and Claude Code functionality, see the test scripts in [vllm/tests/](vllm/tests/). Full documentation is in [vllm/README.md](vllm/README.md).
+
+        ---
+
+        ## Cleanup
+
+        Resources to delete, by deployment option:
+
+        **Option A (Anthropic API):**
+
+        ```bash
+        oc delete deployment claude-code
+        oc delete buildconfig claude-code
+        oc delete imagestream claude-code
+        oc delete secret claude-credentials
+        oc delete configmap claude-mcp-config claude-skills claude-settings
+        oc delete pvc claude-workspace
+        oc delete project my-claude-project
+        ```
+
+        **Option B (Vertex AI):**
+
+        ```bash
+        oc delete deployment claude-code-vertex
+        oc delete buildconfig claude-code
+        oc delete imagestream claude-code
+        oc delete secret claude-vertex-credentials
+        oc delete configmap claude-vertex-config claude-vertex-mcp-config claude-vertex-skills claude-vertex-settings
+        oc delete pvc claude-vertex-workspace
+        oc delete project my-claude-project
+        ```
+
+        **Option C (vLLM direct):**
+
+        ```bash
+        oc delete deployment claude-code-vllm
+        oc delete buildconfig claude-code
+        oc delete imagestream claude-code
+        oc delete configmap claude-vllm-settings claude-vllm-mcp-config claude-vllm-skills
+        oc delete pvc claude-vllm-workspace
+        oc delete project my-claude-project
+        ```
+
+        **Option D (OGX + vLLM):**
+
+        ```bash
+        oc delete deployment claude-code-ogx-vllm
+        oc delete buildconfig claude-code
+        oc delete imagestream claude-code
+        oc delete configmap claude-ogx-vllm-settings claude-ogx-vllm-mcp-config claude-ogx-vllm-skills
+        oc delete pvc claude-ogx-vllm-workspace
+        oc delete project my-claude-project
+        ```
+
+        ---
+
+        ## Known Limitations
+
+        ### Context Window Requirement
+
+        Claude Code sends a large internal system prompt (~23K tokens) with every request. Models with insufficient context will fail. Minimum: 32K tokens. Recommended: 128K+ for multi-turn conversations with tool use.
+
+        ### Open Source Model Quality
+
+        Claude Code is designed and optimized for Anthropic's Claude models. Open source models may produce lower quality results, particularly for complex multi-step tasks, tool use chains, and code generation. Including language runtimes in the container helps because the agent can run tests and iterate on its own output.
+
+        ### LLMInferenceService vs Standalone Deployment
+
+        The KServe `LLMInferenceService` CRD adds a `storage-initializer` init container that uses HF Xet for model downloads. This can stall on large models (60GB+) due to CDN timeouts, and the CRD does not expose init container env overrides. The standalone Deployment approach (used in [vllm/README.md](vllm/README.md)) lets vLLM download the model directly with standard HTTP, which is more reliable.
+
+        Use `LLMInferenceService` when you need the llm-d router/scheduler for multi-replica intelligent routing. Use standalone Deployment for single-replica setups or when the init container stalls.
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/claude-code/templates/claude_code_agent
       framework: claude-code
       labels:
@@ -4451,6 +5504,144 @@ agents:
     - name: openclaw-agent
       displayName: OpenClaw
       description: Open-source AI coding assistant based on OpenClaw with gateway-based model routing and multi-channel support.
+      readme: |
+        # OpenClaw on OpenShift
+
+        > Tested: 2026-04-13 on OpenShift 4.19 (ROSA) with vLLM model serving
+
+        **⚠ Important:** The container image used in this starter kit
+        (`ghcr.io/openclaw/openclaw`) is built and published by the
+        [OpenClaw upstream community](https://github.com/openclaw/openclaw),
+        **not by Red Hat**. It has not been built, scanned, or validated
+        according to Red Hat standards. Use it at your own discretion.
+        A Red Hat supported image may be provided in a future release.
+
+        Deploy [OpenClaw](https://github.com/openclaw/openclaw) on Red Hat OpenShift with vLLM model serving — no cluster-admin required.
+
+        For the full deployment guide, see [docs/raw-deployment.md](docs/raw-deployment.md).
+
+        ## Prerequisites
+
+        - OpenShift 4.17+ with namespace-scoped access (`oc login`)
+        - A model serving endpoint (vLLM, KServe, or external API)
+        - Block storage class (gp3-csi, managed-csi, thin-csi) — not NFS
+
+        ## Quick Start
+
+        ```bash
+        oc new-project my-openclaw
+
+        # Edit manifests/02-configmap.yaml with your model endpoint
+        # Edit manifests/01-secret.yaml with your gateway token
+
+        oc apply -k manifests/
+        ```
+
+        ## Architecture
+
+        ```text
+                             +-----------------------+
+                             |   OpenShift Route     |
+                             |   (TLS edge)          |
+                             +-----------+-----------+
+                                         |
+                                         v
+                      +------------------+------------------+
+                      |            Service                   |
+                      |        (ClusterIP :18789)            |
+                      +------------------+------------------+
+                                         |
+                                         v
+                      +------------------+------------------+
+                      |              Pod                     |
+                      |  +--------------------------------+  |
+                      |  | gateway                        |  |
+                      |  | port 18789                     |  |
+                      |  +---------------+----------------+  |
+                      |                  |                   |
+                      |           +------+------+            |
+                      |           | PVC (5Gi)   |            |
+                      |           +-------------+            |
+                      +--------------------------------------+
+                                 |
+                                 | OpenAI-compatible API
+                                 v
+                      +---------------------------+
+                      |  vLLM / KServe / API      |
+                      +---------------------------+
+        ```
+
+        ## Files
+
+        | File | Description |
+        |------|-------------|
+        | `manifests/01-secret.yaml` | Gateway authentication token |
+        | `manifests/02-configmap.yaml` | Model endpoint and gateway configuration |
+        | `manifests/03-pvc.yaml` | Persistent storage for gateway state |
+        | `manifests/04-deployment.yaml` | OpenClaw gateway deployment |
+        | `manifests/05-service.yaml` | ClusterIP service |
+        | `manifests/06-route.yaml` | TLS edge route |
+        | `manifests/kustomization.yaml` | Kustomize entrypoint |
+        | `overlays/example/` | Example overlay for environment-specific config |
+        | `overlays/mlflow-tracing/` | MLflow tracing via OTel collector sidecar |
+        | `Containerfile.openshell` | OpenShell sandbox image build |
+
+        ## Customization
+
+        | What | Where |
+        |------|-------|
+        | Model endpoint URL | `overlays/<env>/configmap-patch.yaml` |
+        | Storage class | `overlays/<env>/kustomization.yaml` (patch) |
+        | Namespace | `overlays/<env>/kustomization.yaml` (`namespace:` field) |
+        | Gateway token | `manifests/01-secret.yaml` |
+        | Resource limits | Patch `manifests/04-deployment.yaml` |
+
+        ## Docs
+
+        | Document | Description |
+        |----------|-------------|
+        | [docs/raw-deployment.md](docs/raw-deployment.md) | Full deployment guide: configuration, validation, troubleshooting |
+        | [docs/mlflow-tracing.md](docs/mlflow-tracing.md) | MLflow tracing with OTel collector sidecar |
+        | [docs/model-compatibility.md](docs/model-compatibility.md) | Model testing results for agentic tool-calling |
+        | [docs/troubleshooting.md](docs/troubleshooting.md) | Common issues and fixes |
+        | [docs/installer-deployment.md](docs/installer-deployment.md) | Alternative deployment via [claw-installer](https://github.com/sallyom/claw-installer) |
+
+        ## Related Projects
+
+        - [OpenClaw](https://github.com/openclaw/openclaw) — Upstream project
+        - [claw-installer](https://github.com/sallyom/claw-installer) — Web-based deployment tool with OpenShift plugin
+        - [openclaw-on-openshift](https://github.com/aakankshaduggal/openclaw-on-openshift) — Source repo with full docs
+
+        ---
+
+        ## Running in an OpenShell Sandbox
+
+        To run OpenClaw inside an [OpenShell](https://github.com/NVIDIA/OpenShell-Community) sandbox, use the `Containerfile.openshell`. This builds on the shared base image (`sandboxes/base/`) and adds Node.js and the OpenClaw CLI on top.
+
+        ### Build the OpenShell-compatible image
+
+        ```bash
+        podman build --platform linux/amd64 -t openclaw-sandbox:latest -f Containerfile.openshell .
+        ```
+
+        ### Create a sandbox
+
+        ```bash
+        openshell sandbox create --from openclaw-sandbox:latest
+        ```
+
+        ### What `Containerfile.openshell` does
+
+        Builds on the shared base image (`quay.io/hmoghani/openshell-base`) which provides the `sandbox` user, system packages, and OpenShell entrypoint. This flavor adds:
+
+        - Node.js and npm (from UBI repos)
+        - OpenClaw via npm (version pinned, MIT)
+
+        ### Notes
+
+        - OpenShell's supervisor takes over as PID 1 and does not automatically start the OpenClaw gateway. Start it manually inside the sandbox: `openclaw gateway --bind loopback --auth none --port 18789 --allow-unconfigured`
+        - Build with `--platform linux/amd64` when targeting x86_64 clusters from Apple Silicon machines.
+        - Tested on OpenShell v0.0.58, OpenShift 4.21 (June 2026).
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/openclaw/templates/openclaw_agent
       framework: openclaw
       labels:
@@ -4472,6 +5663,40 @@ agents:
     - name: opencode-agent
       displayName: OpenCode
       description: AI-powered terminal-based coding agent built on OpenCode for code generation, editing, and debugging tasks.
+      readme: |
+        # OpenCode — OpenShell Sandbox Deployment
+
+        This directory contains an OpenShell-compatible Containerfile for running [OpenCode](https://github.com/sst/opencode) inside an OpenShell sandbox.
+
+        ## Prerequisites
+
+        - [Podman](https://podman.io/) or Docker installed
+        - [OpenShell CLI](https://github.com/NVIDIA/OpenShell-Community) installed
+        - An OpenShell gateway running
+
+        ## Build and Run
+
+        ```bash
+        podman build --platform linux/amd64 -t opencode-sandbox:latest -f Containerfile.openshell .
+        openshell sandbox create --from opencode-sandbox:latest
+        ```
+
+        ## What `Containerfile.openshell` does
+
+        Builds on the shared base image (`quay.io/hmoghani/openshell-base`) which provides the `sandbox` user, system packages, and OpenShell entrypoint. This flavor adds:
+
+        - Node.js and npm (from UBI repos)
+        - OpenCode via npm (version pinned, MIT)
+
+        ## RHOAI Deployment
+
+        For deploying OpenCode on Red Hat OpenShift AI with OAuth, kustomize manifests, and production configuration, see [DEPLOYMENT.md](DEPLOYMENT.md).
+
+        ## Notes
+
+        - OpenShell's supervisor takes over as PID 1 and does not automatically run OpenCode. Start it manually inside the sandbox.
+        - Build with `--platform linux/amd64` when targeting x86_64 clusters from Apple Silicon machines.
+        - Tested on OpenShell v0.0.58, OpenShift 4.21 (June 2026). OpenCode version 1.17.1.
       repositoryUrl: https://github.com/red-hat-data-services/agentic-starter-kits/tree/main/agents/opencode/templates/opencode_agent
       framework: opencode
       labels:

--- a/data/redhat-agents-index.yaml
+++ b/data/redhat-agents-index.yaml
@@ -16,5 +16,8 @@ agents:
   - path: agents/a2a/templates/langgraph_crewai_agent
 
   - path: agents/claude-code/templates/claude_code_agent
+    readmePath: agents/claude-code
   - path: agents/openclaw/templates/openclaw_agent
+    readmePath: agents/openclaw/deployment
   - path: agents/opencode/templates/opencode_agent
+    readmePath: agents/opencode/deployment

--- a/data/redhat-agents-index.yaml
+++ b/data/redhat-agents-index.yaml
@@ -15,7 +15,6 @@ agents:
   - path: agents/langflow/templates/simple_tool_calling_agent
   - path: agents/a2a/templates/langgraph_crewai_agent
 
-  - path: agents/claude-code/templates/claude_code
-  - path: agents/openclaw/templates/openclaw
-  - path: agents/codex/templates/codex
-  - path: agents/opencode/templates/opencode
+  - path: agents/claude-code/templates/claude_code_agent
+  - path: agents/openclaw/templates/openclaw_agent
+  - path: agents/opencode/templates/opencode_agent

--- a/data/redhat-agents-index.yaml
+++ b/data/redhat-agents-index.yaml
@@ -15,24 +15,7 @@ agents:
   - path: agents/langflow/templates/simple_tool_calling_agent
   - path: agents/a2a/templates/langgraph_crewai_agent
 
-  # Deployment-only agents (no agent.yaml upstream — metadata inline)
-  - path: agents/claude-code
-    name: claude-code
-    displayName: "Claude Code on OpenShift"
-    framework: claude-code
-    description: "Deploy Claude Code on OpenShift with multiple backend options (Anthropic API, Vertex AI, vLLM, OGX)."
-  - path: agents/openclaw/deployment
-    name: openclaw
-    displayName: "OpenClaw on OpenShift"
-    framework: openclaw
-    description: "Deploy OpenClaw on OpenShift with vLLM model serving, OAuth SSO, and production-grade security."
-  - path: agents/codex/deployment
-    name: codex
-    displayName: "Codex on OpenShift"
-    framework: codex
-    description: "Run OpenAI Codex CLI inside an OpenShell sandbox on OpenShift."
-  - path: agents/opencode/deployment
-    name: opencode
-    displayName: "OpenCode on OpenShift"
-    framework: opencode
-    description: "Run OpenCode inside an OpenShell sandbox on OpenShift."
+  - path: agents/claude-code/templates/claude_code
+  - path: agents/openclaw/templates/openclaw
+  - path: agents/codex/templates/codex
+  - path: agents/opencode/templates/opencode

--- a/internal/catalog/agent_catalog.go
+++ b/internal/catalog/agent_catalog.go
@@ -112,7 +112,11 @@ func buildAgentMetadata(repo, branch, rawRef string, entry types.AgentIndexEntry
 			agent.Templates = buildTemplateArtifacts(upstream.RawContent)
 		}
 
-		readme, err := github.FetchReadme(repo, rawRef, entry.Path)
+		readmePath := entry.Path
+		if entry.ReadmePath != "" {
+			readmePath = entry.ReadmePath
+		}
+		readme, err := github.FetchReadme(repo, rawRef, readmePath)
 		if err != nil {
 			log.Printf("  Warning: failed to fetch README for %s: %v", entry.Path, err)
 		} else if readme != "" {

--- a/internal/catalog/agent_catalog.go
+++ b/internal/catalog/agent_catalog.go
@@ -105,8 +105,11 @@ func buildAgentMetadata(repo, branch, rawRef string, entry types.AgentIndexEntry
 			agent.DisplayName = upstream.DisplayName
 			agent.Framework = upstream.Framework
 			agent.Description = upstream.Description
+			agent.Labels = upstream.Labels
+			agent.Logo = upstream.Logo
 			agent.Env = transformEnvVars(upstream)
 			forwardExtraAsCustomProperties(agent, upstream.Extra)
+			agent.Templates = buildTemplateArtifacts(upstream.RawContent)
 		}
 
 		readme, err := github.FetchReadme(repo, rawRef, entry.Path)
@@ -192,6 +195,23 @@ func forwardExtraAsCustomProperties(agent *types.AgentMetadata, extra map[string
 			StringValue:  strVal,
 		}
 	}
+}
+
+// buildTemplateArtifacts serializes the full upstream agent.yaml content as a
+// JSON-encoded template artifact for the catalog output.
+func buildTemplateArtifacts(rawContent map[string]interface{}) []types.AgentTemplate {
+	if len(rawContent) == 0 {
+		return nil
+	}
+	jsonBytes, err := json.Marshal(rawContent)
+	if err != nil {
+		log.Printf("  Warning: could not serialize agent.yaml for template artifact: %v", err)
+		return nil
+	}
+	return []types.AgentTemplate{{
+		Name:    "agent.yaml",
+		Content: string(jsonBytes),
+	}}
 }
 
 // agentSupportTierFromSource maps an index Source value to a supportTier string.

--- a/internal/catalog/agent_catalog_test.go
+++ b/internal/catalog/agent_catalog_test.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +10,119 @@ import (
 
 	"github.com/opendatahub-io/model-metadata-collection/pkg/types"
 )
+
+func TestBuildTemplateArtifacts(t *testing.T) {
+	t.Run("generates JSON template from raw content", func(t *testing.T) {
+		raw := map[string]interface{}{
+			"name":        "test-agent",
+			"displayName": "Test Agent",
+			"framework":   "langgraph",
+			"description": "A test agent.",
+			"labels":      []interface{}{"tool-calling", "react"},
+			"logo":        "data:image/svg+xml;base64,abc123",
+		}
+		templates := buildTemplateArtifacts(raw)
+		if len(templates) != 1 {
+			t.Fatalf("expected 1 template, got %d", len(templates))
+		}
+		if templates[0].Name != "agent.yaml" {
+			t.Errorf("expected template name 'agent.yaml', got %q", templates[0].Name)
+		}
+		// Verify content is valid JSON containing the original fields
+		var parsed map[string]interface{}
+		if err := json.Unmarshal([]byte(templates[0].Content), &parsed); err != nil {
+			t.Fatalf("template content is not valid JSON: %v", err)
+		}
+		if parsed["name"] != "test-agent" {
+			t.Errorf("expected name 'test-agent' in template content, got %v", parsed["name"])
+		}
+		if parsed["framework"] != "langgraph" {
+			t.Errorf("expected framework 'langgraph' in template content, got %v", parsed["framework"])
+		}
+	})
+
+	t.Run("returns nil for empty raw content", func(t *testing.T) {
+		templates := buildTemplateArtifacts(nil)
+		if templates != nil {
+			t.Errorf("expected nil templates for nil input, got %v", templates)
+		}
+		templates = buildTemplateArtifacts(map[string]interface{}{})
+		if templates != nil {
+			t.Errorf("expected nil templates for empty map, got %v", templates)
+		}
+	})
+}
+
+func TestLabelsLogoMapping(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	index := types.AgentsIndex{
+		Source:     "Test",
+		Repository: "org/repo",
+		Branch:     "main",
+		Agents: []types.AgentIndexEntry{
+			{
+				Path:        "agents/test",
+				Name:        "test-agent",
+				Framework:   "langgraph",
+				Description: "A test agent.",
+			},
+		},
+	}
+	indexPath := filepath.Join(tmpDir, "index.yaml")
+	writeYAML(t, indexPath, index)
+
+	catalogPath := filepath.Join(tmpDir, "catalog.yaml")
+	err := CreateAgentsCatalog(indexPath, catalogPath, "", true)
+	if err != nil {
+		t.Fatalf("CreateAgentsCatalog failed: %v", err)
+	}
+
+	data, err := os.ReadFile(catalogPath)
+	if err != nil {
+		t.Fatalf("Failed to read catalog: %v", err)
+	}
+	var catalog types.AgentsCatalog
+	if err := yaml.Unmarshal(data, &catalog); err != nil {
+		t.Fatalf("Failed to parse catalog: %v", err)
+	}
+
+	agent := catalog.Agents[0]
+	// With skipEnrichment=true, labels/logo should be empty (no upstream fetch)
+	if len(agent.Labels) != 0 {
+		t.Errorf("expected empty labels with skipEnrichment, got %v", agent.Labels)
+	}
+	if agent.Logo != "" {
+		t.Errorf("expected empty logo with skipEnrichment, got %q", agent.Logo)
+	}
+}
+
+func TestLabelsLogoNotInCustomProperties(t *testing.T) {
+	upstream := &types.UpstreamAgentYAML{
+		Extra: map[string]interface{}{
+			"deploymentModel": "flow-import",
+		},
+	}
+	// Labels and logo should NOT appear in Extra because they are in KnownUpstreamFields
+	if types.KnownUpstreamFields["labels"] != true {
+		t.Error("expected 'labels' in KnownUpstreamFields")
+	}
+	if types.KnownUpstreamFields["logo"] != true {
+		t.Error("expected 'logo' in KnownUpstreamFields")
+	}
+
+	agent := &types.AgentMetadata{}
+	forwardExtraAsCustomProperties(agent, upstream.Extra)
+	if _, found := agent.CustomProperties["labels"]; found {
+		t.Error("labels should not be in customProperties")
+	}
+	if _, found := agent.CustomProperties["logo"]; found {
+		t.Error("logo should not be in customProperties")
+	}
+	if _, found := agent.CustomProperties["deploymentModel"]; !found {
+		t.Error("deploymentModel should be in customProperties")
+	}
+}
 
 func TestTransformEnvVars(t *testing.T) {
 	upstream := &types.UpstreamAgentYAML{}

--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -140,9 +140,11 @@ func FetchAgentYAML(repo, branch, agentPath string) (*types.UpstreamAgentYAML, e
 		return nil, fmt.Errorf("error parsing agent.yaml from %s: %v", agentPath, err)
 	}
 
-	// Capture fields not in the struct as Extra for customProperties forwarding.
+	// Capture the full parsed YAML for template artifact generation, and
+	// extract unknown fields as Extra for customProperties forwarding.
 	var raw map[string]interface{}
 	if err := yaml.Unmarshal(body, &raw); err == nil {
+		agent.RawContent = raw
 		extra := make(map[string]interface{})
 		for k, v := range raw {
 			if !types.KnownUpstreamFields[k] {

--- a/pkg/types/agent.go
+++ b/pkg/types/agent.go
@@ -23,22 +23,25 @@ type AgentsIndex struct {
 // agentic-starter-kits repo. Any fields not listed here are captured in
 // Extra and forwarded as customProperties in the catalog output.
 type UpstreamAgentYAML struct {
-	Name        string `yaml:"name"`
-	DisplayName string `yaml:"displayName"`
-	Framework   string `yaml:"framework"`
-	Description string `yaml:"description"`
+	Name        string   `yaml:"name"`
+	DisplayName string   `yaml:"displayName"`
+	Framework   string   `yaml:"framework"`
+	Description string   `yaml:"description"`
+	Labels      []string `yaml:"labels"`
+	Logo        string   `yaml:"logo"`
 	Env         struct {
 		Required []string `yaml:"required"`
 		Optional []string `yaml:"optional"`
 	} `yaml:"env"`
-	Extra map[string]interface{} `yaml:"-"`
+	Extra      map[string]interface{} `yaml:"-"`
+	RawContent map[string]interface{} `yaml:"-"`
 }
 
 // KnownUpstreamFields lists the agent.yaml keys that are handled explicitly
 // and should NOT be forwarded into customProperties.
 var KnownUpstreamFields = map[string]bool{
 	"name": true, "displayName": true, "framework": true,
-	"description": true, "env": true,
+	"description": true, "labels": true, "logo": true, "env": true,
 }
 
 // AgentEnvVar represents an environment variable for an agent.
@@ -54,6 +57,13 @@ type AgentArtifact struct {
 	LastUpdateTimeSinceEpoch string `yaml:"lastUpdateTimeSinceEpoch,omitempty"`
 }
 
+// AgentTemplate represents a deployment template artifact for an agent.
+// Content holds the full agent.yaml specification as a JSON-encoded string.
+type AgentTemplate struct {
+	Name    string `yaml:"name,omitempty"`
+	Content string `yaml:"content"`
+}
+
 // AgentMetadata represents the full metadata for a single agent in the catalog.
 type AgentMetadata struct {
 	Name                     string                   `yaml:"name"`
@@ -67,6 +77,7 @@ type AgentMetadata struct {
 	Logo                     string                   `yaml:"logo,omitempty"`
 	Env                      []AgentEnvVar            `yaml:"env,omitempty"`
 	Artifacts                []AgentArtifact          `yaml:"artifacts,omitempty"`
+	Templates                []AgentTemplate          `yaml:"templates,omitempty"`
 	CustomProperties         map[string]MetadataValue `yaml:"customProperties,omitempty"`
 	CreateTimeSinceEpoch     string                   `yaml:"createTimeSinceEpoch,omitempty"`
 	LastUpdateTimeSinceEpoch string                   `yaml:"lastUpdateTimeSinceEpoch,omitempty"`

--- a/pkg/types/agent.go
+++ b/pkg/types/agent.go
@@ -5,6 +5,7 @@ package types
 // For deployment-only agents without agent.yaml, metadata fields are provided inline.
 type AgentIndexEntry struct {
 	Path        string `yaml:"path"`
+	ReadmePath  string `yaml:"readmePath,omitempty"`
 	Name        string `yaml:"name,omitempty"`
 	DisplayName string `yaml:"displayName,omitempty"`
 	Framework   string `yaml:"framework,omitempty"`


### PR DESCRIPTION
## Summary

- Add optional `readmePath` field to `AgentIndexEntry` for agents whose README lives outside the `agent.yaml` directory
- Used by claude-code (`agents/claude-code`), openclaw (`agents/openclaw/deployment`), and opencode (`agents/opencode/deployment`)
- Include 3 newly added agents from [agentic-starter-kits#256](https://github.com/red-hat-data-services/agentic-starter-kits/pull/256)
- Regenerate catalog: all 14 agents now have labels, logo, templates, and READMEs

## Test plan

- [x] `make test` — all 10 packages pass
- [x] `make process-agents` — produces catalog with 14 agents
- [x] All 14 agents have `labels`, `logo`, `templates`, and `readme` fields
- [x] All 14 template JSON contents validated as parseable JSON

Ref: RHOAIENG-76086

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the agent catalog with labels, logos, environment details, frameworks, and reusable deployment templates.
  - Added catalog support for additional agents, including Claude Code, OpenClaw, OpenCode, LangGraph, CrewAI, and others.
  - Added clearer README associations and embedded agent configuration templates for supported entries.

- **Documentation**
  - Added testing guidance for the A2A LangGraph–CrewAI agent.
  - Clarified container image provenance for OpenClaw.
  - Updated Claude Code architecture documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->