### PR TITLE
feat(mcp): migrate to canonical reverse-DNS names and semver versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,14 @@ During `make process`, artifacts are enriched from OCI registries (architectures
 
 ### Adding a New MCP Server
 
+**Naming requirements**: `name` must be canonical `<reverse-dns-namespace>/<slug>`
+(e.g. `com.redhat/openshift-mcp-server`, not `redhat/openshift-mcp-server`) and
+`version` must be valid [semver](https://semver.org/) (e.g. `0.4.0`, not `0.4`
+or `latest`). `display_name` is an optional human-facing label. Invalid values
+are rejected by `MCPServerMetadata.Validate()` in `pkg/types/mcpserver.go` and
+halt catalog generation — see [CONTRIBUTING.md](CONTRIBUTING.md#mcp-server-naming-conventions)
+for details.
+
 **For Red Hat MCP servers:**
 1. Create `input/mcp_servers/redhat/<server-name>.yaml` (use an existing file as template)
 2. Add an entry to `data/redhat-mcp-servers-index.yaml`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,35 @@ Run with a custom input file:
 ./build/model-extractor --input path/to/index.yaml --output-dir output/custom
 ```
 
+### MCP Server Naming Conventions
+
+To map directly to the mlflow MCP Registry (`name -> server_json.name`,
+`version -> server_json.version`, `display_name -> display_name`), the `name`
+and `version` fields in every MCP server input YAML must follow these rules.
+Invalid values are rejected during catalog generation (`MCPServerMetadata.Validate()`
+in `pkg/types/mcpserver.go`), which halts the build.
+
+- **`name`**: Canonical `<reverse-dns-namespace>/<slug>` format. The namespace
+  must have at least two dot-separated DNS-style labels (e.g. `com.redhat`,
+  `io.confluent`), all lowercase. The slug is lowercase alphanumeric with
+  optional hyphens or dots (e.g. `openshift-mcp-server`). A short slug like
+  `redhat/my-server` is **not** valid — it needs a real reverse-DNS namespace,
+  e.g. `com.redhat/my-server`.
+- **`version`**: Must be valid [semver](https://semver.org/) (e.g. `1.5.0`).
+  Prerelease and build metadata are allowed (e.g. `1.5.0-alpha`,
+  `1.5.0-betaexp.sha.5114f85`). Values like `latest`, `0.4`, or `6.18` are
+  rejected — they must be padded/replaced with a full `major.minor.patch`.
+- **`display_name`** (optional): A human-facing label for the server, shown
+  in place of the canonical `name` in UIs.
+
+Example:
+
+```yaml
+name: com.redhat/openshift-mcp-server
+display_name: OpenShift MCP Server
+version: 0.4.0
+```
+
 ## Test
 
 Run the full test suite:

--- a/data/community-mcp-servers-catalog.yaml
+++ b/data/community-mcp-servers-catalog.yaml
@@ -1,6 +1,6 @@
 source: Community MCP
 mcp_servers:
-    - name: org.mariadb/mcp
+    - name: org.mariadb/mariadb-mcp
       display_name: MariaDB MCP Server
       provider: MariaDB
       license: MIT

--- a/data/community-mcp-servers-catalog.yaml
+++ b/data/community-mcp-servers-catalog.yaml
@@ -1,6 +1,7 @@
 source: Community MCP
 mcp_servers:
-    - name: mariadb/mcp
+    - name: org.mariadb/mcp
+      display_name: MariaDB MCP Server
       provider: MariaDB
       license: MIT
       license_link: https://opensource.org/licenses/MIT
@@ -211,7 +212,8 @@ mcp_servers:
             metadataType: MetadataStringValue
             string_value: "communitySupported"
       lastUpdateTimeSinceEpoch: "1784302696000"
-    - name: mongodb-js/mongodb-mcp-server
+    - name: com.mongodb/mongodb-mcp-server
+      display_name: MongoDB MCP Server
       provider: MongoDB
       license: Apache-2.0
       license_link: https://www.apache.org/licenses/LICENSE-2.0

--- a/data/community-mcp-servers-index.yaml
+++ b/data/community-mcp-servers-index.yaml
@@ -1,6 +1,6 @@
 source: Community MCP
 mcp_servers:
-  - name: mariadb-mcp
+  - name: org.mariadb/mcp
     input_path: input/mcp_servers/community/mariadb-mcp.yaml
-  - name: mongodb-js-mongodb-mcp-server
+  - name: com.mongodb/mongodb-mcp-server
     input_path: input/mcp_servers/community/mongodb-js-mongodb-mcp-server.yaml

--- a/data/community-mcp-servers-index.yaml
+++ b/data/community-mcp-servers-index.yaml
@@ -1,6 +1,6 @@
 source: Community MCP
 mcp_servers:
-  - name: org.mariadb/mcp
+  - name: org.mariadb/mariadb-mcp
     input_path: input/mcp_servers/community/mariadb-mcp.yaml
   - name: com.mongodb/mongodb-mcp-server
     input_path: input/mcp_servers/community/mongodb-js-mongodb-mcp-server.yaml

--- a/data/partner-mcp-servers-catalog.yaml
+++ b/data/partner-mcp-servers-catalog.yaml
@@ -1,6 +1,7 @@
 source: Partner MCP
 mcp_servers:
-    - name: confluentinc/mcp-confluent
+    - name: io.confluent/mcp-confluent
+      display_name: Confluent MCP Server
       provider: Confluent
       license: MIT
       license_link: https://opensource.org/licenses/MIT
@@ -171,7 +172,8 @@ mcp_servers:
             metadataType: MetadataStringValue
             string_value: "partnerSupported"
       lastUpdateTimeSinceEpoch: "1784301797000"
-    - name: dynatrace-oss/dynatrace-mcp
+    - name: com.dynatrace/dynatrace-mcp
+      display_name: Dynatrace MCP Server
       provider: Dynatrace
       license: MIT
       license_link: https://opensource.org/licenses/MIT
@@ -427,7 +429,8 @@ mcp_servers:
             metadataType: MetadataStringValue
             string_value: "partnerSupported"
       lastUpdateTimeSinceEpoch: "1784301820000"
-    - name: hashicorp/terraform-mcp-server
+    - name: com.hashicorp/terraform-mcp-server
+      display_name: Terraform MCP Server
       provider: IBM Terraform
       license: MPL-2.0
       license_link: https://www.mozilla.org/en-US/MPL/2.0/
@@ -650,7 +653,8 @@ mcp_servers:
             metadataType: MetadataStringValue
             string_value: "partnerSupported"
       lastUpdateTimeSinceEpoch: "1784301817000"
-    - name: microsoft/azure-mcp-server
+    - name: com.microsoft/azure-mcp-server
+      display_name: Azure MCP Server
       provider: Microsoft
       license: MIT
       license_link: https://opensource.org/licenses/MIT
@@ -1073,7 +1077,8 @@ mcp_servers:
             metadataType: MetadataStringValue
             string_value: "partnerSupported"
       lastUpdateTimeSinceEpoch: "1784302076000"
-    - name: enterprisedb/pg-airman-mcp
+    - name: com.enterprisedb/pg-airman-mcp
+      display_name: EDB PG Airman MCP
       provider: EnterpriseDB
       license: Apache-2.0
       license_link: https://www.apache.org/licenses/LICENSE-2.0

--- a/data/partner-mcp-servers-index.yaml
+++ b/data/partner-mcp-servers-index.yaml
@@ -1,12 +1,12 @@
 source: Partner MCP
 mcp_servers:
-  - name: confluentinc-mcp-confluent
+  - name: io.confluent/mcp-confluent
     input_path: input/mcp_servers/partner/confluentinc-mcp-confluent.yaml
-  - name: dynatrace-oss-dynatrace-mcp
+  - name: com.dynatrace/dynatrace-mcp
     input_path: input/mcp_servers/partner/dynatrace-oss-dynatrace-mcp.yaml
-  - name: hashicorp-terraform-mcp-server
+  - name: com.hashicorp/terraform-mcp-server
     input_path: input/mcp_servers/partner/hashicorp-terraform-mcp-server.yaml
-  - name: microsoft-azure-mcp-server
+  - name: com.microsoft/azure-mcp-server
     input_path: input/mcp_servers/partner/microsoft-azure-mcp-server.yaml
-  - name: enterprisedb-pg-airman-mcp
+  - name: com.enterprisedb/pg-airman-mcp
     input_path: input/mcp_servers/partner/enterprisedb-pg-airman-mcp.yaml

--- a/data/redhat-mcp-servers-catalog.yaml
+++ b/data/redhat-mcp-servers-catalog.yaml
@@ -1,6 +1,7 @@
 source: Red Hat MCP
 mcp_servers:
-    - name: openshift-mcp-server
+    - name: com.redhat/openshift-mcp-server
+      display_name: OpenShift MCP Server
       provider: Red Hat
       license: apache-2.0
       license_link: https://www.apache.org/licenses/LICENSE-2.0
@@ -37,7 +38,7 @@ mcp_servers:
         available tools depends on configuration — toolsets can be enabled or disabled,
         and individual tools within a toolset can be filtered using allow/deny lists.
         See [Tool Filtering](https://github.com/openshift/openshift-mcp-server/blob/release-0.4/docs/configuration.md#tool-filtering) for details.
-      version: "0.4"
+      version: 0.4.0
       transports:
         - http
         - sse
@@ -295,7 +296,8 @@ mcp_servers:
             string_value: "redHatSupported"
       createTimeSinceEpoch: "1753228800000"
       lastUpdateTimeSinceEpoch: "1785344616000"
-    - name: aap-mcp-server
+    - name: com.redhat/aap-mcp-server
+      display_name: Ansible Automation Platform MCP Server
       provider: Red Hat
       license: apache-2.0
       license_link: https://www.apache.org/licenses/LICENSE-2.0
@@ -453,7 +455,8 @@ mcp_servers:
             string_value: "redHatSupported"
       createTimeSinceEpoch: "1769990400000"
       lastUpdateTimeSinceEpoch: "1783953395000"
-    - name: insights-mcp-server
+    - name: com.redhat/insights-mcp-server
+      display_name: Red Hat Lightspeed MCP Server
       provider: Red Hat
       license: apache-2.0
       license_link: https://www.apache.org/licenses/LICENSE-2.0
@@ -492,7 +495,7 @@ mcp_servers:
           --from-literal=client-secret=your-client-secret
         ```
         The server exposes an HTTP endpoint on port 8000 and SSE on port 9000.
-      version: latest
+      version: 0.1.0
       transports:
         - http
         - sse

--- a/data/redhat-mcp-servers-index.yaml
+++ b/data/redhat-mcp-servers-index.yaml
@@ -1,8 +1,8 @@
 source: Red Hat MCP
 mcp_servers:
-  - name: openshift-mcp-server
+  - name: com.redhat/openshift-mcp-server
     input_path: input/mcp_servers/redhat/openshift-mcp-server.yaml
-  - name: aap-mcp-server
+  - name: com.redhat/aap-mcp-server
     input_path: input/mcp_servers/redhat/aap-mcp-server.yaml
-  - name: insights-mcp-server
+  - name: com.redhat/insights-mcp-server
     input_path: input/mcp_servers/redhat/insights-mcp-server.yaml

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24
 toolchain go1.25.7
 
 require (
+	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/containers/image/v5 v5.36.1
 	golang.org/x/text v0.28.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
+github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/input/mcp_servers/community/mariadb-mcp.yaml
+++ b/input/mcp_servers/community/mariadb-mcp.yaml
@@ -1,4 +1,5 @@
-name: mariadb/mcp
+name: org.mariadb/mcp
+display_name: MariaDB MCP Server
 provider: MariaDB
 license: MIT
 license_link: https://opensource.org/licenses/MIT

--- a/input/mcp_servers/community/mariadb-mcp.yaml
+++ b/input/mcp_servers/community/mariadb-mcp.yaml
@@ -1,4 +1,4 @@
-name: org.mariadb/mcp
+name: org.mariadb/mariadb-mcp
 display_name: MariaDB MCP Server
 provider: MariaDB
 license: MIT

--- a/input/mcp_servers/community/mongodb-js-mongodb-mcp-server.yaml
+++ b/input/mcp_servers/community/mongodb-js-mongodb-mcp-server.yaml
@@ -1,4 +1,5 @@
-name: mongodb-js/mongodb-mcp-server
+name: com.mongodb/mongodb-mcp-server
+display_name: MongoDB MCP Server
 provider: MongoDB
 license: Apache-2.0
 license_link: https://www.apache.org/licenses/LICENSE-2.0

--- a/input/mcp_servers/partner/confluentinc-mcp-confluent.yaml
+++ b/input/mcp_servers/partner/confluentinc-mcp-confluent.yaml
@@ -1,4 +1,5 @@
-name: confluentinc/mcp-confluent
+name: io.confluent/mcp-confluent
+display_name: Confluent MCP Server
 provider: Confluent
 license: MIT
 license_link: https://opensource.org/licenses/MIT

--- a/input/mcp_servers/partner/dynatrace-oss-dynatrace-mcp.yaml
+++ b/input/mcp_servers/partner/dynatrace-oss-dynatrace-mcp.yaml
@@ -1,4 +1,5 @@
-name: dynatrace-oss/dynatrace-mcp
+name: com.dynatrace/dynatrace-mcp
+display_name: Dynatrace MCP Server
 provider: Dynatrace
 license: MIT
 license_link: https://opensource.org/licenses/MIT

--- a/input/mcp_servers/partner/enterprisedb-pg-airman-mcp.yaml
+++ b/input/mcp_servers/partner/enterprisedb-pg-airman-mcp.yaml
@@ -1,4 +1,5 @@
-name: enterprisedb/pg-airman-mcp
+name: com.enterprisedb/pg-airman-mcp
+display_name: EDB PG Airman MCP
 provider: EnterpriseDB
 license: Apache-2.0
 license_link: https://www.apache.org/licenses/LICENSE-2.0

--- a/input/mcp_servers/partner/hashicorp-terraform-mcp-server.yaml
+++ b/input/mcp_servers/partner/hashicorp-terraform-mcp-server.yaml
@@ -1,4 +1,5 @@
-name: hashicorp/terraform-mcp-server
+name: com.hashicorp/terraform-mcp-server
+display_name: Terraform MCP Server
 provider: IBM Terraform
 license: MPL-2.0
 license_link: https://www.mozilla.org/en-US/MPL/2.0/

--- a/input/mcp_servers/partner/microsoft-azure-mcp-server.yaml
+++ b/input/mcp_servers/partner/microsoft-azure-mcp-server.yaml
@@ -1,4 +1,5 @@
-name: microsoft/azure-mcp-server
+name: com.microsoft/azure-mcp-server
+display_name: Azure MCP Server
 provider: Microsoft
 license: MIT
 license_link: https://opensource.org/licenses/MIT

--- a/input/mcp_servers/redhat/aap-mcp-server.yaml
+++ b/input/mcp_servers/redhat/aap-mcp-server.yaml
@@ -1,4 +1,5 @@
-name: aap-mcp-server
+name: com.redhat/aap-mcp-server
+display_name: Ansible Automation Platform MCP Server
 provider: Red Hat
 license: apache-2.0
 license_link: https://www.apache.org/licenses/LICENSE-2.0

--- a/input/mcp_servers/redhat/insights-mcp-server.yaml
+++ b/input/mcp_servers/redhat/insights-mcp-server.yaml
@@ -1,4 +1,5 @@
-name: insights-mcp-server
+name: com.redhat/insights-mcp-server
+display_name: Red Hat Lightspeed MCP Server
 provider: Red Hat
 license: apache-2.0
 license_link: https://www.apache.org/licenses/LICENSE-2.0
@@ -37,7 +38,7 @@ readme: |-
       --from-literal=client-secret=your-client-secret
     ```
     The server exposes an HTTP endpoint on port 8000 and SSE on port 9000.
-version: latest
+version: 0.1.0
 transports:
     - http
     - sse

--- a/input/mcp_servers/redhat/openshift-mcp-server.yaml
+++ b/input/mcp_servers/redhat/openshift-mcp-server.yaml
@@ -1,4 +1,5 @@
-name: openshift-mcp-server
+name: com.redhat/openshift-mcp-server
+display_name: OpenShift MCP Server
 provider: Red Hat
 license: apache-2.0
 license_link: https://www.apache.org/licenses/LICENSE-2.0
@@ -35,7 +36,7 @@ readme: |-
     available tools depends on configuration — toolsets can be enabled or disabled,
     and individual tools within a toolset can be filtered using allow/deny lists.
     See [Tool Filtering](https://github.com/openshift/openshift-mcp-server/blob/release-0.4/docs/configuration.md#tool-filtering) for details.
-version: 0.4
+version: 0.4.0
 transports:
     - http
     - sse

--- a/input/mcp_servers/redhat/satellite-mcp-server.yaml
+++ b/input/mcp_servers/redhat/satellite-mcp-server.yaml
@@ -1,4 +1,5 @@
-name: satellite-mcp-server
+name: com.redhat/satellite-mcp-server
+display_name: Red Hat Satellite MCP Server
 provider: Red Hat
 license: gpl-3.0
 license_link: https://www.gnu.org/licenses/gpl-3.0.en.html
@@ -37,7 +38,7 @@ readme: |-
     --from-file=ca.pem=/path/to/satellite-ca-bundle.pem
   ```
   The server is configured with `--foreman-url https://satellite.example.com`.
-version: "6.18"
+version: "6.18.0"
 transports:
   - http
   - sse

--- a/internal/catalog/mcp_catalog.go
+++ b/internal/catalog/mcp_catalog.go
@@ -36,13 +36,14 @@ func CreateMCPServersCatalog(indexPath, catalogPath string) error {
 	for _, entry := range index.MCPServers {
 		cleaned := filepath.Clean(entry.InputPath)
 		if filepath.IsAbs(cleaned) || strings.HasPrefix(cleaned, "..") {
-			log.Printf("Warning: skipping MCP server %q: invalid input_path %q (absolute or traversal path not allowed)", entry.Name, entry.InputPath)
-			continue
+			return fmt.Errorf("MCP server %q: invalid input_path %q (absolute or traversal path not allowed)", entry.Name, entry.InputPath)
 		}
 		server, err := loadMCPServerInput(cleaned)
 		if err != nil {
-			log.Printf("Warning: skipping MCP server %q: %v", entry.Name, err)
-			continue
+			return err
+		}
+		if server.Name != entry.Name {
+			return fmt.Errorf("MCP server name mismatch: index has %q but %s declares %q", entry.Name, cleaned, server.Name)
 		}
 		injectSupportTier(server, supportTier)
 		servers = append(servers, *server)
@@ -88,20 +89,18 @@ func loadMCPServerInput(inputPath string) (*types.MCPServerMetadata, error) {
 	}
 
 	var missing []string
-	if server.Name == "" {
-		missing = append(missing, "name")
-	}
 	if server.Provider == "" {
 		missing = append(missing, "provider")
 	}
 	if server.Description == "" {
 		missing = append(missing, "description")
 	}
-	if server.Version == "" {
-		missing = append(missing, "version")
-	}
 	if len(missing) > 0 {
 		return nil, fmt.Errorf("input file %s missing required field(s): %s", inputPath, strings.Join(missing, ", "))
+	}
+
+	if err := server.Validate(); err != nil {
+		return nil, fmt.Errorf("input file %s: %v", inputPath, err)
 	}
 
 	return &server, nil

--- a/internal/catalog/mcp_catalog_test.go
+++ b/internal/catalog/mcp_catalog_test.go
@@ -23,11 +23,11 @@ func TestCreateMCPServersCatalog(t *testing.T) {
 		}
 
 		server1 := types.MCPServerMetadata{
-			Name:        "test-server-1",
+			Name:        "com.example/test-server-1",
 			Provider:    "Red Hat",
 			License:     "apache-2.0",
 			Description: "Test server 1",
-			Version:     "latest",
+			Version:     "1.0.0",
 			Tools: []types.MCPTool{
 				{Name: "list_items", Description: "List items", AccessType: "read_only", Parameters: []types.MCPParameter{}},
 			},
@@ -36,11 +36,11 @@ func TestCreateMCPServersCatalog(t *testing.T) {
 			},
 		}
 		server2 := types.MCPServerMetadata{
-			Name:        "test-server-2",
+			Name:        "com.example/test-server-2",
 			Provider:    "Red Hat",
 			License:     "apache-2.0",
 			Description: "Test server 2",
-			Version:     "1.0",
+			Version:     "1.0.0",
 		}
 
 		writeYAML(t, filepath.Join(inputDir, "test-server-1.yaml"), server1)
@@ -50,8 +50,8 @@ func TestCreateMCPServersCatalog(t *testing.T) {
 		index := types.MCPServersIndex{
 			Source: "Red Hat MCP",
 			MCPServers: []types.MCPServerEntry{
-				{Name: "test-server-1", InputPath: filepath.Join(inputDir, "test-server-1.yaml")},
-				{Name: "test-server-2", InputPath: filepath.Join(inputDir, "test-server-2.yaml")},
+				{Name: "com.example/test-server-1", InputPath: filepath.Join(inputDir, "test-server-1.yaml")},
+				{Name: "com.example/test-server-2", InputPath: filepath.Join(inputDir, "test-server-2.yaml")},
 			},
 		}
 		indexPath := "index.yaml"
@@ -81,11 +81,11 @@ func TestCreateMCPServersCatalog(t *testing.T) {
 		if len(catalog.MCPServers) != 2 {
 			t.Fatalf("expected 2 servers, got %d", len(catalog.MCPServers))
 		}
-		if catalog.MCPServers[0].Name != "test-server-1" {
-			t.Errorf("expected first server 'test-server-1', got %q", catalog.MCPServers[0].Name)
+		if catalog.MCPServers[0].Name != "com.example/test-server-1" {
+			t.Errorf("expected first server 'com.example/test-server-1', got %q", catalog.MCPServers[0].Name)
 		}
-		if catalog.MCPServers[1].Name != "test-server-2" {
-			t.Errorf("expected second server 'test-server-2', got %q", catalog.MCPServers[1].Name)
+		if catalog.MCPServers[1].Name != "com.example/test-server-2" {
+			t.Errorf("expected second server 'com.example/test-server-2', got %q", catalog.MCPServers[1].Name)
 		}
 		if len(catalog.MCPServers[0].Tools) != 1 {
 			t.Errorf("expected 1 tool for server 1, got %d", len(catalog.MCPServers[0].Tools))
@@ -105,7 +105,7 @@ func TestCreateMCPServersCatalog(t *testing.T) {
 		}
 	})
 
-	t.Run("missing input file is skipped", func(t *testing.T) {
+	t.Run("missing input file halts catalog generation", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Chdir(tmpDir)
 
@@ -116,10 +116,10 @@ func TestCreateMCPServersCatalog(t *testing.T) {
 		}
 
 		server := types.MCPServerMetadata{
-			Name:        "good-server",
+			Name:        "com.example/good-server",
 			Provider:    "Red Hat",
 			Description: "Good test server",
-			Version:     "latest",
+			Version:     "1.0.0",
 		}
 		writeYAML(t, filepath.Join(inputDir, "good-server.yaml"), server)
 
@@ -127,8 +127,8 @@ func TestCreateMCPServersCatalog(t *testing.T) {
 		index := types.MCPServersIndex{
 			Source: "Red Hat MCP",
 			MCPServers: []types.MCPServerEntry{
-				{Name: "good-server", InputPath: filepath.Join(inputDir, "good-server.yaml")},
-				{Name: "missing-server", InputPath: filepath.Join(inputDir, "missing-server.yaml")},
+				{Name: "com.example/good-server", InputPath: filepath.Join(inputDir, "good-server.yaml")},
+				{Name: "com.example/missing-server", InputPath: filepath.Join(inputDir, "missing-server.yaml")},
 			},
 		}
 		indexPath := "index.yaml"
@@ -136,29 +136,12 @@ func TestCreateMCPServersCatalog(t *testing.T) {
 
 		catalogPath := "catalog.yaml"
 		err := CreateMCPServersCatalog(indexPath, catalogPath)
-		if err != nil {
-			t.Fatalf("CreateMCPServersCatalog should not fail on missing input: %v", err)
-		}
-
-		// Verify only the valid server is in the catalog
-		data, err := os.ReadFile(catalogPath)
-		if err != nil {
-			t.Fatalf("Failed to read catalog: %v", err)
-		}
-		var catalog types.MCPServersCatalog
-		if err := yaml.Unmarshal(data, &catalog); err != nil {
-			t.Fatalf("Failed to parse catalog: %v", err)
-		}
-
-		if len(catalog.MCPServers) != 1 {
-			t.Fatalf("expected 1 server (skipping missing), got %d", len(catalog.MCPServers))
-		}
-		if catalog.MCPServers[0].Name != "good-server" {
-			t.Errorf("expected 'good-server', got %q", catalog.MCPServers[0].Name)
+		if err == nil {
+			t.Fatal("expected CreateMCPServersCatalog to fail on missing input file")
 		}
 	})
 
-	t.Run("invalid YAML input is skipped", func(t *testing.T) {
+	t.Run("invalid YAML input halts catalog generation", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Chdir(tmpDir)
 
@@ -182,21 +165,110 @@ func TestCreateMCPServersCatalog(t *testing.T) {
 
 		catalogPath := "catalog.yaml"
 		err := CreateMCPServersCatalog(indexPath, catalogPath)
-		if err != nil {
-			t.Fatalf("CreateMCPServersCatalog should not fail on invalid input: %v", err)
+		if err == nil {
+			t.Fatal("expected CreateMCPServersCatalog to fail on invalid YAML input")
+		}
+	})
+
+	t.Run("invalid name format halts catalog generation", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+
+		inputDir := "input"
+		if err := os.MkdirAll(inputDir, 0755); err != nil {
+			t.Fatal(err)
 		}
 
-		data, err := os.ReadFile(catalogPath)
-		if err != nil {
-			t.Fatalf("Failed to read catalog: %v", err)
+		server := types.MCPServerMetadata{
+			Name:        "no-namespace-server",
+			Provider:    "Red Hat",
+			Description: "Server with invalid name format",
+			Version:     "1.0.0",
 		}
-		var catalog types.MCPServersCatalog
-		if err := yaml.Unmarshal(data, &catalog); err != nil {
-			t.Fatalf("Failed to parse catalog: %v", err)
+		writeYAML(t, filepath.Join(inputDir, "bad-name.yaml"), server)
+
+		index := types.MCPServersIndex{
+			Source: "Red Hat MCP",
+			MCPServers: []types.MCPServerEntry{
+				{Name: "no-namespace-server", InputPath: filepath.Join(inputDir, "bad-name.yaml")},
+			},
+		}
+		indexPath := "index.yaml"
+		writeYAML(t, indexPath, index)
+
+		catalogPath := "catalog.yaml"
+		err := CreateMCPServersCatalog(indexPath, catalogPath)
+		if err == nil {
+			t.Fatal("expected CreateMCPServersCatalog to fail on invalid name format")
+		}
+	})
+
+	t.Run("invalid version format halts catalog generation", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+
+		inputDir := "input"
+		if err := os.MkdirAll(inputDir, 0755); err != nil {
+			t.Fatal(err)
 		}
 
-		if len(catalog.MCPServers) != 0 {
-			t.Errorf("expected 0 servers (invalid skipped), got %d", len(catalog.MCPServers))
+		server := types.MCPServerMetadata{
+			Name:        "com.example/bad-version",
+			Provider:    "Red Hat",
+			Description: "Server with invalid version format",
+			Version:     "latest",
+		}
+		writeYAML(t, filepath.Join(inputDir, "bad-version.yaml"), server)
+
+		index := types.MCPServersIndex{
+			Source: "Red Hat MCP",
+			MCPServers: []types.MCPServerEntry{
+				{Name: "com.example/bad-version", InputPath: filepath.Join(inputDir, "bad-version.yaml")},
+			},
+		}
+		indexPath := "index.yaml"
+		writeYAML(t, indexPath, index)
+
+		catalogPath := "catalog.yaml"
+		err := CreateMCPServersCatalog(indexPath, catalogPath)
+		if err == nil {
+			t.Fatal("expected CreateMCPServersCatalog to fail on invalid version format")
+		}
+	})
+
+	t.Run("index name mismatch with manifest halts catalog generation", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Chdir(tmpDir)
+
+		inputDir := "input"
+		if err := os.MkdirAll(inputDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		server := types.MCPServerMetadata{
+			Name:        "com.example/manifest-name",
+			Provider:    "Red Hat",
+			Description: "Server whose manifest name differs from the index",
+			Version:     "1.0.0",
+		}
+		writeYAML(t, filepath.Join(inputDir, "mismatched.yaml"), server)
+
+		index := types.MCPServersIndex{
+			Source: "Red Hat MCP",
+			MCPServers: []types.MCPServerEntry{
+				{Name: "com.example/index-name", InputPath: filepath.Join(inputDir, "mismatched.yaml")},
+			},
+		}
+		indexPath := "index.yaml"
+		writeYAML(t, indexPath, index)
+
+		catalogPath := "catalog.yaml"
+		err := CreateMCPServersCatalog(indexPath, catalogPath)
+		if err == nil {
+			t.Fatal("expected CreateMCPServersCatalog to fail on index/manifest name mismatch")
+		}
+		if !strings.Contains(err.Error(), "name mismatch") {
+			t.Errorf("expected name mismatch error, got: %v", err)
 		}
 	})
 
@@ -274,30 +346,20 @@ func TestCreateMCPServersCatalog(t *testing.T) {
 		writeYAML(t, indexPath, index)
 
 		catalogPath := filepath.Join(tmpDir, "catalog.yaml")
-		if err := CreateMCPServersCatalog(indexPath, catalogPath); err != nil {
-			t.Fatalf("CreateMCPServersCatalog should not fail on invalid input_path: %v", err)
+		err = CreateMCPServersCatalog(indexPath, catalogPath)
+		if err == nil {
+			t.Fatal("CreateMCPServersCatalog should fail on invalid input_path")
+		}
+		if !strings.Contains(err.Error(), "traversal") {
+			t.Errorf("expected traversal error, got: %v", err)
 		}
 
-		data, err := os.ReadFile(catalogPath)
-		if err != nil {
-			t.Fatalf("Failed to read catalog: %v", err)
-		}
-
-		// Sentinel content must not appear in the catalog output.
-		if strings.Contains(string(data), sentinelMarker) {
-			t.Error("catalog contains sentinel content — path traversal guard was bypassed")
-		}
-
-		var catalog types.MCPServersCatalog
-		if err := yaml.Unmarshal(data, &catalog); err != nil {
-			t.Fatalf("Failed to parse catalog: %v", err)
-		}
-		if len(catalog.MCPServers) != 0 {
-			t.Errorf("expected 0 servers (path traversal rejected), got %d", len(catalog.MCPServers))
+		if _, err := os.Stat(catalogPath); err == nil {
+			t.Error("catalog file should not have been written when input_path is rejected")
 		}
 	})
 
-	t.Run("input with missing required fields is skipped", func(t *testing.T) {
+	t.Run("input with missing required fields halts catalog generation", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		t.Chdir(tmpDir)
 
@@ -322,21 +384,8 @@ func TestCreateMCPServersCatalog(t *testing.T) {
 
 		catalogPath := "catalog.yaml"
 		err := CreateMCPServersCatalog(indexPath, catalogPath)
-		if err != nil {
-			t.Fatalf("CreateMCPServersCatalog should not fail on incomplete input: %v", err)
-		}
-
-		data, err := os.ReadFile(catalogPath)
-		if err != nil {
-			t.Fatalf("Failed to read catalog: %v", err)
-		}
-		var catalog types.MCPServersCatalog
-		if err := yaml.Unmarshal(data, &catalog); err != nil {
-			t.Fatalf("Failed to parse catalog: %v", err)
-		}
-
-		if len(catalog.MCPServers) != 0 {
-			t.Errorf("expected 0 servers (missing required fields rejected), got %d", len(catalog.MCPServers))
+		if err == nil {
+			t.Fatal("expected CreateMCPServersCatalog to fail on input missing required fields")
 		}
 	})
 }

--- a/internal/catalog/mcp_enrichment_test.go
+++ b/internal/catalog/mcp_enrichment_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestEnrichMCPServerArtifacts_EmptyURI(t *testing.T) {
 	server := &types.MCPServerMetadata{
-		Name:     "test-server",
+		Name:     "com.example/test-server",
 		Provider: "Test",
 		Artifacts: []types.MCPArtifact{
 			{URI: ""},
@@ -31,7 +31,7 @@ func TestEnrichMCPServerArtifacts_EmptyURI(t *testing.T) {
 
 func TestEnrichMCPServerArtifacts_NoArtifacts(t *testing.T) {
 	server := &types.MCPServerMetadata{
-		Name:     "test-server",
+		Name:     "com.example/test-server",
 		Provider: "Test",
 	}
 
@@ -46,7 +46,7 @@ func TestEnrichMCPServerArtifacts_NoArtifacts(t *testing.T) {
 
 func TestEnrichMCPServerArtifacts_PublishedDateDerivation(t *testing.T) {
 	server := &types.MCPServerMetadata{
-		Name:          "test-server",
+		Name:          "com.example/test-server",
 		Provider:      "Test",
 		PublishedDate: "2025-07-23T00:00:00Z",
 	}
@@ -73,7 +73,7 @@ func TestEnrichMCPServerArtifacts_PublishedDateDerivation(t *testing.T) {
 
 func TestEnrichMCPServerArtifacts_PublishedDateIdempotent(t *testing.T) {
 	server := &types.MCPServerMetadata{
-		Name:                 "test-server",
+		Name:                 "com.example/test-server",
 		Provider:             "Test",
 		PublishedDate:        "2025-07-23T00:00:00Z",
 		CreateTimeSinceEpoch: "1753228800000",
@@ -110,11 +110,11 @@ func TestWriteMCPServerInput(t *testing.T) {
 	outputPath := filepath.Join(tmpDir, "test-server.yaml")
 
 	server := &types.MCPServerMetadata{
-		Name:        "test-server",
+		Name:        "com.example/test-server",
 		Provider:    "Test Provider",
 		License:     "apache-2.0",
 		Description: "A test server",
-		Version:     "latest",
+		Version:     "1.0.0",
 		Logo:        "data:image/svg+xml;base64," + strings.Repeat("ABCD", 200),
 		CustomProperties: map[string]types.MetadataValue{
 			"architecture": {

--- a/pkg/types/mcpserver.go
+++ b/pkg/types/mcpserver.go
@@ -1,5 +1,18 @@
 package types
 
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// mcpNameRegex enforces the canonical <reverse-dns-namespace>/<slug> format
+// required by the mlflow MCP Registry, e.g. "com.redhat/openshift-mcp-server".
+// The namespace must have at least two dot-separated DNS-style labels; labels
+// may contain internal hyphens but not lead or trail with one (RFC 1035).
+var mcpNameRegex = regexp.MustCompile(`^[a-z]([a-z0-9-]*[a-z0-9])?(\.[a-z]([a-z0-9-]*[a-z0-9])?)+/[a-z][a-z0-9]*([.-][a-z0-9]+)*$`)
+
 // MCPServerEntry represents an entry in the MCP servers index file
 type MCPServerEntry struct {
 	Name      string `yaml:"name"`
@@ -15,6 +28,7 @@ type MCPServersIndex struct {
 // MCPServerMetadata represents the full metadata for a single MCP server
 type MCPServerMetadata struct {
 	Name                     string                   `yaml:"name"`
+	DisplayName              string                   `yaml:"display_name,omitempty"`
 	Provider                 string                   `yaml:"provider"`
 	License                  string                   `yaml:"license"`
 	LicenseLink              string                   `yaml:"license_link"`
@@ -36,6 +50,23 @@ type MCPServerMetadata struct {
 	CustomProperties         map[string]MetadataValue `yaml:"customProperties,omitempty"`
 	CreateTimeSinceEpoch     string                   `yaml:"createTimeSinceEpoch,omitempty"`
 	LastUpdateTimeSinceEpoch string                   `yaml:"lastUpdateTimeSinceEpoch,omitempty"`
+}
+
+// Validate checks that Name follows the canonical <reverse-dns-namespace>/<slug>
+// format and Version is valid semver, per the mlflow MCP Registry mapping
+// (name -> server_json.name, version -> server_json.version). A nil receiver
+// is considered valid (no-op).
+func (m *MCPServerMetadata) Validate() error {
+	if m == nil {
+		return nil
+	}
+	if !mcpNameRegex.MatchString(m.Name) {
+		return fmt.Errorf("mcp server: name %q must be <reverse-dns-namespace>/<slug> with at least two dot-separated namespace components (e.g. com.redhat/openshift-mcp-server)", m.Name)
+	}
+	if _, err := semver.StrictNewVersion(m.Version); err != nil {
+		return fmt.Errorf("mcp server: version %q is not valid semver: %v", m.Version, err)
+	}
+	return nil
 }
 
 // MCPTool represents a tool exposed by an MCP server

--- a/pkg/types/mcpserver_test.go
+++ b/pkg/types/mcpserver_test.go
@@ -1,0 +1,151 @@
+package types
+
+import "testing"
+
+func TestMCPServerMetadata_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		server  *MCPServerMetadata
+		wantErr bool
+	}{
+		{
+			name:    "nil receiver is valid",
+			server:  nil,
+			wantErr: false,
+		},
+		{
+			name:    "valid name and version",
+			server:  &MCPServerMetadata{Name: "com.redhat/openshift-mcp-server", Version: "0.4.0"},
+			wantErr: false,
+		},
+		{
+			name:    "valid name with three namespace labels",
+			server:  &MCPServerMetadata{Name: "io.github.confluentinc/mcp-confluent", Version: "1.0.0"},
+			wantErr: false,
+		},
+		{
+			name:    "valid name with digits in namespace",
+			server:  &MCPServerMetadata{Name: "com.web3/tool", Version: "1.0.0"},
+			wantErr: false,
+		},
+		{
+			name:    "valid name with dot in slug",
+			server:  &MCPServerMetadata{Name: "org.mariadb/mcp.server", Version: "1.0.0"},
+			wantErr: false,
+		},
+		{
+			name:    "valid name matching real mariadb production entry",
+			server:  &MCPServerMetadata{Name: "org.mariadb/mcp", Version: "1.0.0"},
+			wantErr: false,
+		},
+		{
+			name:    "valid name with hyphen in namespace label",
+			server:  &MCPServerMetadata{Name: "com.my-company/their-server", Version: "1.0.0"},
+			wantErr: false,
+		},
+		{
+			name:    "valid name with single-character slug",
+			server:  &MCPServerMetadata{Name: "com.example/x", Version: "1.0.0"},
+			wantErr: false,
+		},
+		{
+			name:    "valid prerelease version",
+			server:  &MCPServerMetadata{Name: "com.redhat/openshift-mcp-server", Version: "2.0.0-beta"},
+			wantErr: false,
+		},
+		{
+			name:    "valid prerelease with dotted identifiers",
+			server:  &MCPServerMetadata{Name: "com.redhat/openshift-mcp-server", Version: "0.1.0-rc.1"},
+			wantErr: false,
+		},
+		{
+			name:    "valid version with build metadata",
+			server:  &MCPServerMetadata{Name: "com.redhat/openshift-mcp-server", Version: "1.5.0-betaexp.sha.5114f85"},
+			wantErr: false,
+		},
+		{
+			name:    "valid version with plus build metadata",
+			server:  &MCPServerMetadata{Name: "com.redhat/openshift-mcp-server", Version: "1.0.0+build.123"},
+			wantErr: false,
+		},
+		{
+			name:    "name missing namespace",
+			server:  &MCPServerMetadata{Name: "openshift-mcp-server", Version: "1.0.0"},
+			wantErr: true,
+		},
+		{
+			name:    "name with single-label namespace",
+			server:  &MCPServerMetadata{Name: "redhat/openshift-mcp-server", Version: "1.0.0"},
+			wantErr: true,
+		},
+		{
+			name:    "name with uppercase characters",
+			server:  &MCPServerMetadata{Name: "COM.RedHat/openshift-mcp-server", Version: "1.0.0"},
+			wantErr: true,
+		},
+		{
+			name:    "empty name",
+			server:  &MCPServerMetadata{Name: "", Version: "1.0.0"},
+			wantErr: true,
+		},
+		{
+			name:    "name with empty slug",
+			server:  &MCPServerMetadata{Name: "com.redhat/", Version: "1.0.0"},
+			wantErr: true,
+		},
+		{
+			name:    "name with empty namespace",
+			server:  &MCPServerMetadata{Name: "/openshift-mcp-server", Version: "1.0.0"},
+			wantErr: true,
+		},
+		{
+			name:    "name with underscore in slug",
+			server:  &MCPServerMetadata{Name: "com.redhat/my_server", Version: "1.0.0"},
+			wantErr: true,
+		},
+		{
+			name:    "name with leading hyphen in namespace label",
+			server:  &MCPServerMetadata{Name: "com.-bad/server", Version: "1.0.0"},
+			wantErr: true,
+		},
+		{
+			name:    "name with trailing hyphen in namespace label",
+			server:  &MCPServerMetadata{Name: "com.bad-/server", Version: "1.0.0"},
+			wantErr: true,
+		},
+		{
+			name:    "version is latest",
+			server:  &MCPServerMetadata{Name: "com.redhat/openshift-mcp-server", Version: "latest"},
+			wantErr: true,
+		},
+		{
+			name:    "version missing patch component",
+			server:  &MCPServerMetadata{Name: "com.redhat/openshift-mcp-server", Version: "0.4"},
+			wantErr: true,
+		},
+		{
+			name:    "version is a two-component product version",
+			server:  &MCPServerMetadata{Name: "com.redhat/satellite-mcp-server", Version: "6.18"},
+			wantErr: true,
+		},
+		{
+			name:    "empty version",
+			server:  &MCPServerMetadata{Name: "com.redhat/openshift-mcp-server", Version: ""},
+			wantErr: true,
+		},
+		{
+			name:    "version with v prefix",
+			server:  &MCPServerMetadata{Name: "com.redhat/openshift-mcp-server", Version: "v1.0.0"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.server.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Makes MCP catalog data directly mappable to the mlflow MCP Registry (`name` -> `server_json.name`, `version` -> `server_json.version,` `display_name` -> `display_name).` Adds `MCPServerMetadata.Validate()` to enforce `<reverse-dns-namespace>/<slug>` names and strict semver versions, and makes catalog generation fail hard on invalid data instead of silently skipping it. Migrates all Red Hat, partner, and community MCP server entries and regenerates the checked-in catalogs.

RHOAIENG-70086

## How Has This Been Tested?

Loaded the generated container image on the catalog in a dev environment:

```
$ curl -s 'http://localhost:8082/api/mcp_catalog/v1alpha1/mcp_servers' | jq '.items[] | {"name": .name, "version": .version}'
{
  "name": "org.mariadb/mcp",
  "version": "1.0.0"
}
{
  "name": "io.confluent/mcp-confluent",
  "version": "1.0.0"
}
{
  "name": "com.redhat/openshift-mcp-server",
  "version": "0.4.0"
}
{
  "name": "com.mongodb/mongodb-mcp-server",
  "version": "1.0.0"
}
{
  "name": "com.dynatrace/dynatrace-mcp",
  "version": "1.4.0"
}
{
  "name": "com.redhat/aap-mcp-server",
  "version": "1.0.0"
}
{
  "name": "com.redhat/insights-mcp-server",
  "version": "0.1.0"
}
{
  "name": "com.hashicorp/terraform-mcp-server",
  "version": "0.4.0"
}
{
  "name": "com.microsoft/azure-mcp-server",
  "version": "2.0.0-beta"
}
{
  "name": "com.enterprisedb/pg-airman-mcp",
  "version": "1.0.0"
}
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits have meaningful messages; the author will squash them [after approval](https://github.com/opendatahub-io/opendatahub-community/blob/main/contributor-cheatsheet.md#:~:text=Usually%20this%20is%20done%20in%20last%20phase%20of%20a%20PR%20revision) or will ask to merge with squash.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized, organization-qualified names for MCP servers.
  * Added optional display names and strict semantic version support.
* **Bug Fixes**
  * Catalog generation now fails clearly for invalid metadata, missing files, malformed configurations, and mismatched server names.
  * Updated server listings with consistent naming and valid versions.
* **Documentation**
  * Documented MCP server naming, version, display name, and validation requirements.
* **Tests**
  * Expanded coverage for metadata validation and catalog generation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->